### PR TITLE
Update models for asset,audit,config,movement,exchange,mobileterminal.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,18 +30,18 @@
         <equalsverifier.version>2.3.3</equalsverifier.version>
 
         <usm4uvms.version>3.0.8</usm4uvms.version>
-        <uvms.config.version>3.1.1</uvms.config.version>
+        <uvms.config.version>4.0.0</uvms.config.version>
         <uvms.common.version>2.0.29</uvms.common.version>
-        <movement.model.version>3.0.8</movement.model.version>
-        <exchange.model.version>3.0.7</exchange.model.version>
-        <mobileterminal.model.version>3.0.9</mobileterminal.model.version>
+        <movement.model.version>4.0.0</movement.model.version>
+        <exchange.model.version>4.0.0</exchange.model.version>
+        <mobileterminal.model.version>4.0.0</mobileterminal.model.version>
         <user.model.version>2.0.0</user.model.version>
 
         <activity.model.version>0.5.13</activity.model.version>
         <mdr.model.version>0.5.2</mdr.model.version>
 
-        <asset.model.version>3.0.7</asset.model.version>
-        <audit.model.version>3.0.5</audit.model.version>
+        <asset.model.version>4.0.0</asset.model.version>
+        <audit.model.version>4.0.0</audit.model.version>
         <rules.model.version>3.0.8</rules.model.version>
         <sales.model.version>1.0.4</sales.model.version>
 
@@ -213,6 +213,47 @@
                 <release.branch.name>uvms-3.0.5-C3PO</release.branch.name>
             </properties>
         </profile>
+        <!-- enforce-jdk-version -->
+        <profile>
+            <id>enforce-jdk-version</id>
+            <activation>
+                <!-- To disable profile, define property -Dfocus-pom.enforce.jdk.version.disabled=true -->
+                <property>
+                    <name>!focus-pom.enforce.jdk.version.disabled</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>enforce-jdk-version</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[${focus-pom.java.version},${focus-pom.java.version}.999)</version>
+                                        </requireJavaVersion>
+                                        <enforceBytecodeVersion>
+                                            <maxJdkVersion>${focus-pom.java.version}</maxJdkVersion>
+                                            <!-- NOTE: xstream do contain support for multiple jdk:s -->
+                                            <excludes>
+                    							<exclude>com.thoughtworks.xstream:xstream</exclude>
+                  							</excludes>
+                                        </enforceBytecodeVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -240,6 +281,9 @@
             </plugin>
         </plugins>
     </build>
+
+
+
     <modules>
         <module>rest</module>
         <module>service</module>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -35,8 +35,8 @@
  			<dependency>
 			    <groupId>com.thoughtworks.xstream</groupId>
 			    <artifactId>xstream</artifactId>
-			    <version>1.4.10-java7</version>
-			</dependency>            	
+			    <version>1.4.10</version>
+			</dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -63,25 +63,21 @@
             <groupId>eu.europa.ec.fisheries.uvms.movement</groupId>
             <artifactId>movement-model</artifactId>
             <version>${movement.model.version}</version>
-            <classifier>date</classifier>
         </dependency>
         <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.asset</groupId>
             <artifactId>asset-model</artifactId>
             <version>${asset.model.version}</version>
-            <classifier>date</classifier>
         </dependency>
         <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.mobileterminal</groupId>
             <artifactId>mobileterminal-model</artifactId>
             <version>${mobileterminal.model.version}</version>
-            <classifier>date</classifier>
         </dependency>
         <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.exchange</groupId>
             <artifactId>exchange-model</artifactId>
             <version>${exchange.model.version}</version>
-            <classifier>date</classifier>
         </dependency>
         <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.user</groupId>
@@ -110,7 +106,7 @@
         <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.config</groupId>
             <artifactId>config-model</artifactId>
-            <version>3.0.4</version>
+            <version>4.0.0</version>
         </dependency>
 
         <!-- drools dependencies -->
@@ -121,8 +117,8 @@
         <dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-		</dependency>            	
-        
+		</dependency>
+
         <dependency>
             <groupId>org.drools</groupId>
             <artifactId>drools-compiler</artifactId>
@@ -163,20 +159,9 @@
     <build>
         <finalName>${project.name}-${project.version}</finalName>
         <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ejb-plugin</artifactId>
-                <version>2.3</version>
                 <configuration>
                     <ejbVersion>3.1</ejbVersion>
                 </configuration>
@@ -184,7 +169,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0-alpha-2</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>


### PR DESCRIPTION
New baseline 4.0.0 is released since 3.0.X was changed in most cases
compared to 3.0.0. 

Add exclude for xstream from bytecode enforcement since it contains
classes with support for multiple jdk:s below, but main classes compiled
with 1.5

JAVA_1_4_HOME: /opt/blackdown-jdk-1.4.2.03
JAVA_1_5_HOME: /opt/sun-jdk-1.5.0.22
JAVA_1_6_HOME: /opt/sun-jdk-1.6.0.45
JAVA_1_7_HOME: /opt/oracle-jdk-bin-1.7.0.80
JAVA_1_8_HOME: /opt/oracle-jdk-bin-1.8.0.131
JAVA_1_9_HOME: /opt/oracle-jdk-bin-1.9.0.0_beta167