### PR TITLE
Fix belgian-specific activity flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <mobileterminal.model.version>4.0.0</mobileterminal.model.version>
         <user.model.version>2.0.2</user.model.version>
 
-        <activity.model.version>0.5.13</activity.model.version>
+        <activity.model.version>0.5.14-SNAPSHOT</activity.model.version>
         <mdr.model.version>0.5.2</mdr.model.version>
 
         <asset.model.version>4.0.0</asset.model.version>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MessageServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MessageServiceBean.java
@@ -585,7 +585,7 @@ public class MessageServiceBean implements MessageService {
             String df = request.getFluxDataFlow(); //e.g. "urn:un:unece:uncefact:fisheries:FLUX:FA:EU:2" // TODO should come from subscription. Also could be a link between DF and AD value
             String destination = request.getSenderOrReceiver();  // e.g. "AHR:VMS"
             String messageGuid = ActivityFactMapper.getUUID(fluxResponseMessageType.getFLUXResponseDocument().getIDS());
-            String fluxFAReponseText = ExchangeModuleRequestMapper.createFluxFAResponseRequest(fluxResponse, request.getUsername(), df, messageGuid, nationCode, status, destination, getExchangePluginType(pluginType));
+            String fluxFAReponseText = ExchangeModuleRequestMapper.createFluxFAResponseRequest(fluxResponse, request.getUsername(), df, messageGuid, getExchangePluginType(pluginType), nationCode, status, destination, getExchangePluginType(pluginType));
             log.debug("Message to exchange {}", fluxFAReponseText);
 
             producer.sendDataSourceMessage(fluxFAReponseText, DataSourceQueue.EXCHANGE);

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MessageServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MessageServiceBean.java
@@ -585,7 +585,7 @@ public class MessageServiceBean implements MessageService {
             String df = request.getFluxDataFlow(); //e.g. "urn:un:unece:uncefact:fisheries:FLUX:FA:EU:2" // TODO should come from subscription. Also could be a link between DF and AD value
             String destination = request.getSenderOrReceiver();  // e.g. "AHR:VMS"
             String messageGuid = ActivityFactMapper.getUUID(fluxResponseMessageType.getFLUXResponseDocument().getIDS());
-            String fluxFAReponseText = ExchangeModuleRequestMapper.createFluxFAResponseRequest(fluxResponse, request.getUsername(), df, messageGuid, getExchangePluginType(pluginType), nationCode, status, destination, getExchangePluginType(pluginType));
+            String fluxFAReponseText = ExchangeModuleRequestMapper.createFluxFAResponseRequest(fluxResponse, request.getUsername(), df, messageGuid, nationCode, status, destination, getExchangePluginType(pluginType));
             log.debug("Message to exchange {}", fluxFAReponseText);
 
             producer.sendDataSourceMessage(fluxFAReponseText, DataSourceQueue.EXCHANGE);


### PR DESCRIPTION
A new enum type should be sent to Activity. This requires a dependency to the newest version of Activity-model.