### PR TITLE
Improve startup time

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/FactRuleEvaluator.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/FactRuleEvaluator.java
@@ -185,6 +185,7 @@ public class FactRuleEvaluator {
 
     private Collection<KiePackage> createAllPackages(Map<String, String> drlsAndRules) {
         Collection<KiePackage> compiledPackages = new ArrayList<>();
+        KieContainer container = null;
         for (Map.Entry<String, String> ruleEntrySet : drlsAndRules.entrySet()) {
             String rule = ruleEntrySet.getKey();
             String templateName = ruleEntrySet.getValue();
@@ -200,10 +201,12 @@ public class FactRuleEvaluator {
                 continue;
             }
             kieFileSystem.generateAndWritePomXML(kieServices.getRepository().getDefaultReleaseId());
-            KieContainer container = kieServices.newKieContainer(kieServices.getRepository().getDefaultReleaseId());
+            container = kieServices.newKieContainer(kieServices.getRepository().getDefaultReleaseId());
 
-            KieBase kBase = container.getKieBase();
-            compiledPackages = kBase.getKiePackages();
+        }
+        
+        if (container != null) {
+        	compiledPackages = container.getKieBase().getKiePackages();        	
         }
         return compiledPackages;
     }


### PR DESCRIPTION
Improve the startup time of rules.

BEFORE : 13:25:28 -- 13:31:15 =  5min 47sec
NOW : 15:44:53 -- 15:49:02 =  4min 9 sec 

[startupTimeNew.txt](https://github.com/UnionVMS/UVMS-RulesModule-APP/files/1372180/startupTimeNew.txt)
[startupTimeOld.txt](https://github.com/UnionVMS/UVMS-RulesModule-APP/files/1372181/startupTimeOld.txt)

