### PR TITLE
Fix flow from Sales to FLUX + improve randomly failing test

### DIFF
--- a/LIQUIBASE/schema/initdata/rule_init.xml
+++ b/LIQUIBASE/schema/initdata/rule_init.xml
@@ -8337,6 +8337,7 @@
             <column name="error_type" value="WARNING"/>
             <column name="template_id" value="1002"/>
             <column name="property_names" value="IDS"/>
+            <column name="disabled" value="true"/>
         </insert>
 
         <!-- Sales_Document  -->
@@ -8500,6 +8501,7 @@
             <column name="error_type" value="WARNING"/>
             <column name="template_id" value="1002"/>
             <column name="property_names" value="IDS"/>
+            <column name="disabled" value="true"/>
         </insert>
 
     </changeSet>

--- a/LIQUIBASE/schema/initdata/rule_init.xml
+++ b/LIQUIBASE/schema/initdata/rule_init.xml
@@ -8475,6 +8475,7 @@
             <column name="error_type" value="ERROR"/>
             <column name="template_id" value="1023"/>
             <column name="property_names" value="referencedId"/>
+            <column name="disabled" value="true"/>
         </insert>
         <insert tableName="rule">
             <column name="rule_id" value="11103"/>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MessageServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MessageServiceBean.java
@@ -216,7 +216,7 @@ public class MessageServiceBean implements MessageService {
             String requestForExchange = ExchangeModuleRequestMapper.createSendSalesResponseRequest(rulesRequest.getRequest(),
                     rulesRequest.getMessageGuid(),
                     rulesRequest.getFluxDataFlow(),
-                    rulesRequest.getPluginToSendResponseThrough(),
+                    rulesRequest.getRecipient(),
                     rulesRequest.getDateSent(),
                     validationStatus);
             sendToExchange(requestForExchange);

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesMessageFactory.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesMessageFactory.java
@@ -17,6 +17,12 @@ import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 @Stateless
 public class SalesMessageFactory {
 
+    public static final String FLUX_GP_VALIDATION_TYPE_ERR = "ERR";
+    public static final String FLUX_GP_VALIDATION_TYPE_WAR = "WAR";
+    public static final String FLUX_GP_RESPONSE_NOK = "NOK";
+    public static final String FLUX_GP_RESPONSE_WOK = "WOK";
+    public static final String FLUX_GP_RESPONSE_OK = "OK";
+
     public String createSalesQueryRequest(String request, ValidationResultDto validationResult, String pluginType) throws SalesMarshallException {
         List<ValidationQualityAnalysisType> validationQualityAnalysis = mapToValidationQualityAnalysis(validationResult);
         String messageStatus = getMessageStatus(validationResult);
@@ -52,19 +58,19 @@ public class SalesMessageFactory {
 
     protected String getErrorType(ErrorType errorType) {
         switch (errorType) {
-            case ERROR: return "ERR";
-            case WARNING: return "WAR";
+            case ERROR: return FLUX_GP_VALIDATION_TYPE_ERR;
+            case WARNING: return FLUX_GP_VALIDATION_TYPE_WAR;
             default: throw new UnsupportedOperationException("No mapping provided for a validation message with error type " + errorType);
         }
     }
 
     protected String getMessageStatus(ValidationResultDto validationResultDto) {
         if (validationResultDto.isError()) {
-            return "NOK";
+            return FLUX_GP_RESPONSE_NOK;
         } else if (validationResultDto.isWarning()) {
-            return "WOK";
+            return FLUX_GP_RESPONSE_WOK;
         } else {
-            return "OK";
+            return FLUX_GP_RESPONSE_OK;
         }
     }
 

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesMessageFactoryTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesMessageFactoryTest.java
@@ -75,7 +75,7 @@ public class SalesMessageFactoryTest {
     @Test
     public void mapToValidationQualityAnalysisWhenNoValidationMessagesAndListIsEmpty() {
         ValidationResultDto validationResultDto = new ValidationResultDto();
-        validationResultDto.setValidationMessages(new ArrayList<>());
+        validationResultDto.setValidationMessages(new ArrayList<ValidationMessageType>());
 
         assertEquals(new ArrayList<>(), salesMessageFactory.mapToValidationQualityAnalysis(validationResultDto));
     }

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/ActivityServiceBeanHelperTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/ActivityServiceBeanHelperTest.java
@@ -23,7 +23,6 @@ import javax.jms.TextMessage;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -114,14 +113,15 @@ public class ActivityServiceBeanHelperTest {
         fishingTripResponse.getFishingActivityLists().add(new FishingActivitySummary());
         fishingTripResponse.getFishingTripIdLists().add(new FishingTripIdWithGeometry());
 
-        when(JAXBMarshaller.unmarshallString(message, FishingTripResponse.class))
-                .thenReturn(fishingTripResponse);
-        when(ActivityModuleRequestMapper.mapToActivityGetFishingTripRequest(listFilter, singleFilters)).thenReturn("FishingTripResponse");
-
         TextMessage mockTextMessage = mock(TextMessage.class);
         doReturn(message).when(mockTextMessage).getText();
         doReturn(mockTextMessage).when(messageConsumer).getMessage(correlationId, TextMessage.class);
         doReturn(correlationId).when(messageProducer).sendDataSourceMessage("FishingTripResponse", DataSourceQueue.ACTIVITY);
+
+        when(JAXBMarshaller.unmarshallString(message, FishingTripResponse.class))
+                .thenReturn(fishingTripResponse);
+        when(ActivityModuleRequestMapper.mapToActivityGetFishingTripRequest(listFilter, singleFilters)).thenReturn("FishingTripResponse");
+
 
         Optional<FishingTripResponse> fishingTripResponseOptional = helper.findTrip(fishingTripID);
 


### PR DESCRIPTION
Fixes a bug where the addressee of a Sales FLUX message becomes "FLUX", instead of the real addressee.
Some improvements have been made to a test that is *sometimes* failing. The number of failures have not been reduced to zero, however, so we still put @Ignore on the test, until we find out what's really wrong.