### PR TITLE
Bug/change rules to use date for mdr lists

### DIFF
--- a/LIQUIBASE/schema/initdata/rule_init.xml
+++ b/LIQUIBASE/schema/initdata/rule_init.xml
@@ -37,7 +37,8 @@
             <column name="expression"
                     value="!isEmpty(nonUniqueIdsList) &amp;&amp; listContainsAtLeastOneFromTheOtherList(ids, nonUniqueIdsList)"/>
             <column name="note"
-                    value="If it exists already, the contents are considered identical and the message may be ignored by the receiving party.                                        It is expected to return the same validation results."/>
+                    value="If it exists already, the contents are considered identical and the message may be ignored by the receiving party.
+                     It is expected to return the same validation results."/>
             <column name="message" value="Message ID already exists."/>
             <column name="level" value="L03"/>
             <column name="error_type" value="ERROR"/>
@@ -875,7 +876,7 @@
             <column name="rule_id" value="88"/>
             <column name="br_id" value="FA-L01-00-0088"/>
             <column name="expression"
-                    value="countryID != null &amp;&amp; countryID.schemeId != null &amp;&amp; countryID.value != null &amp;&amp; !mdrService.isPresentInMDRList(countryID.schemeId, countryID.value)"/>
+                    value="countryID != null &amp;&amp; countryID.schemeId != null &amp;&amp; countryID.value != null &amp;&amp; !mdrService.isPresentInMDRList(countryID.schemeId, countryID.value, creationDateOfMessage)"/>
             <column name="note"
                     value="Specified Structured_Address CountryID value must be existing in the list specified by CountryID@SchemeId."/>
             <column name="message"
@@ -932,7 +933,7 @@
             <column name="rule_id" value="22"/>
             <column name="br_id" value="FA-L01-00-0022"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check code. Must be existing in the list specified in attribute listID."/>
             <column name="message" value="Invalid code for Report type."/>
             <column name="level" value="L01"/>
@@ -1058,7 +1059,7 @@
             <column name="rule_id" value="34"/>
             <column name="br_id" value="FA-L01-00-0034"/>
             <column name="expression"
-                    value="purposeCode != null &amp;&amp; !mdrService.isPresentInMDRList(purposeCode.listId, purposeCode.value)"/>
+                    value="purposeCode != null &amp;&amp; !mdrService.isPresentInMDRList(purposeCode.listId, purposeCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check code. Must be existing in the list specified in attribute listID."/>
             <column name="message" value="PurposeCode has an invalid value."/>
             <column name="level" value="L01"/>
@@ -1344,7 +1345,7 @@
             <column name="rule_id" value="57"/>
             <column name="br_id" value="FA-L01-00-0057"/>
             <column name="expression"
-                    value="isFromFaReport &amp;&amp; roleCode != null &amp;&amp; !mdrService.isPresentInMDRList(roleCode.listId, roleCode.value)"/>
+                    value="isFromFaReport &amp;&amp; roleCode != null &amp;&amp; !mdrService.isPresentInMDRList(roleCode.listId, roleCode.value, creationDateOfMessage)"/>
             <column name="note" value="If provided."/>
             <column name="message" value="RoleCode has an invalid value."/>
             <column name="level" value="L01"/>
@@ -1385,7 +1386,7 @@
             <column name="rule_id" value="60"/>
             <column name="br_id" value="FA-L01-00-0060"/>
             <column name="expression"
-                    value="registrationVesselCountryId != null &amp;&amp; !mdrService.isPresentInMDRList(registrationVesselCountryId.schemeId, registrationVesselCountryId.value)"/>
+                    value="registrationVesselCountryId != null &amp;&amp; !mdrService.isPresentInMDRList(registrationVesselCountryId.schemeId, registrationVesselCountryId.value, creationDateOfMessage)"/>
             <column name="note" value="Check code. Must be existing in the list specified in attribute listID."/>
             <column name="message" value="Invalid value for country of registration."/>
             <column name="level" value="L01"/>
@@ -1524,7 +1525,7 @@
             <column name="rule_id" value="70"/>
             <column name="br_id" value="FA-L01-00-0070"/>
             <column name="expression"
-                    value="isFromFaReport &amp;&amp; !mdrService.isCodeTypePresentInMDRList(&quot;FLUX_CONTACT_ROLE&quot;, specifiedContactPartyRoleCodes)"/>
+                    value="isFromFaReport &amp;&amp; !mdrService.isCodeTypePresentInMDRList(&quot;FLUX_CONTACT_ROLE&quot;, specifiedContactPartyRoleCodes, creationDateOfMessage)"/>
             <column name="note" value="Check code. Must be existing in the list specified in attribute listID"/>
             <column name="message" value="Contact RoleCode has an invalid value."/>
             <column name="level" value="L01"/>
@@ -2428,7 +2429,7 @@
             <column name="rule_id" value="92"/>
             <column name="br_id" value="FA-L01-00-0092"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check code. Must be existing in the list specified in attribute listID"/>
             <column name="message" value="Fishing activity TypeCode value is invalid."/>
             <column name="level" value="L01"/>
@@ -2457,7 +2458,7 @@
             <column name="rule_id" value="97"/>
             <column name="br_id" value="FA-L01-00-0097"/>
             <column name="expression"
-                    value="reasonCode != null &amp;&amp; !mdrService.isPresentInMDRList(reasonCode.listId, reasonCode.value)"/>
+                    value="reasonCode != null &amp;&amp; !mdrService.isPresentInMDRList(reasonCode.listId, reasonCode.value, creationDateOfMessage)"/>
             <column name="note" value="If provided."/>
             <column name="message" value="ReasonCode value invalid."/>
             <column name="level" value="L01"/>
@@ -2471,7 +2472,7 @@
             <column name="rule_id" value="99"/>
             <column name="br_id" value="FA-L01-00-0099"/>
             <column name="expression"
-                    value="fisheryTypeCode != null &amp;&amp; !mdrService.isPresentInMDRList(fisheryTypeCode.listId, fisheryTypeCode.value)"/>
+                    value="fisheryTypeCode != null &amp;&amp; !mdrService.isPresentInMDRList(fisheryTypeCode.listId, fisheryTypeCode.value, creationDateOfMessage)"/>
             <column name="note" value="If provided."/>
             <column name="message" value="FisheryTypeCode value is invalid."/>
             <column name="level" value="L01"/>
@@ -2485,7 +2486,7 @@
             <column name="rule_id" value="101"/>
             <column name="br_id" value="FA-L01-00-0101"/>
             <column name="expression"
-                    value="speciesTargetCode != null &amp;&amp; !mdrService.isPresentInMDRList(speciesTargetCode.listId, speciesTargetCode.value)"/>
+                    value="speciesTargetCode != null &amp;&amp; !mdrService.isPresentInMDRList(speciesTargetCode.listId, speciesTargetCode.value, creationDateOfMessage)"/>
             <column name="note" value="If provided."/>
             <column name="message" value="Invalid Target species."/>
             <column name="level" value="L01"/>
@@ -2499,7 +2500,7 @@
             <column name="rule_id" value="103"/>
             <column name="br_id" value="FA-L01-00-0103"/>
             <column name="expression"
-                    value="vesselRelatedActivityCode != null &amp;&amp; !mdrService.isPresentInMDRList(vesselRelatedActivityCode.listId, vesselRelatedActivityCode.value)"/>
+                    value="vesselRelatedActivityCode != null &amp;&amp; !mdrService.isPresentInMDRList(vesselRelatedActivityCode.listId, vesselRelatedActivityCode.value, creationDateOfMessage)"/>
             <column name="note" value="If provided."/>
             <column name="message" value="Invalid vessel activity."/>
             <column name="level" value="L01"/>
@@ -2671,7 +2672,7 @@
             <column name="rule_id" value="194"/>
             <column name="br_id" value="FA-L01-00-0194"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FISHING_TRIP_TYPE&quot;, typeCode.value) "/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FISHING_TRIP_TYPE&quot;, typeCode.value, creationDateOfMessage) "/>
             <column name="note" value="If provided"/>
             <column name="message" value="Trip ID TypeCode value is invalid."/>
             <column name="level" value="L01"/>
@@ -2712,7 +2713,7 @@
             <column name="rule_id" value="197"/>
             <column name="br_id" value="FA-L01-00-0197"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FLUX_LOCATION_TYPE&quot;, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FLUX_LOCATION_TYPE&quot;, typeCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check typeCode value it Must be present in MDR list FLUX_LOCATION_TYPE."/>
             <column name="message" value="Location TypeCode value is invalid."/>
             <column name="level" value="L01"/>
@@ -2755,7 +2756,7 @@
             <column name="rule_id" value="200"/>
             <column name="br_id" value="FA-L01-00-0200"/>
             <column name="expression"
-                    value="countryID != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;TERRITORY&quot;, countryID.value)"/>
+                    value="countryID != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;TERRITORY&quot;, countryID.value, creationDateOfMessage)"/>
             <column name="note" value="CountyID value must be present in MDR list TERRITORY."/>
             <column name="message" value="Location CountryID value is invalid."/>
             <column name="level" value="L01"/>
@@ -2813,7 +2814,7 @@
             <column name="rule_id" value="203"/>
             <column name="br_id" value="FA-L01-00-0203"/>
             <column name="expression"
-                    value="id != null &amp;&amp; id.schemeId != null &amp;&amp; !mdrService.isPresentInMDRList(id.schemeId, id.value)"/>
+                    value="id != null &amp;&amp; id.schemeId != null &amp;&amp; !mdrService.isPresentInMDRList(id.schemeId, id.value, creationDateOfMessage)"/>
             <column name="note" value="Id value must be present in MDR list specified in schemeId of Id"/>
             <column name="message" value="Location ID value is invalid."/>
             <column name="level" value="L01"/>
@@ -3039,7 +3040,7 @@
             <column name="rule_id" value="205"/>
             <column name="br_id" value="FA-L01-00-0205"/>
             <column name="expression"
-                    value="rfmo != null &amp;&amp; !mdrService.isTypeCodeValuePresentInList(rfmo.listId, rfmo)"/>
+                    value="rfmo != null &amp;&amp; !mdrService.isTypeCodeValuePresentInList(rfmo.listId, rfmo, creationDateOfMessage)"/>
             <column name="note" value="If provided"/>
             <column name="message" value="RFMO code value is invalid."/>
             <column name="level" value="L01"/>
@@ -3080,7 +3081,7 @@
             <column name="rule_id" value="152"/>
             <column name="br_id" value="FA-L01-00-0152"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; typeCode.listId != null &amp;&amp; typeCode.value != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value )"/>
+                    value="typeCode != null &amp;&amp; typeCode.listId != null &amp;&amp; typeCode.value != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check code. Must be existing in the list specified in attribute listID "/>
             <column name="message" value="Check code. Must be existing in the list specified in attribute listID "/>
             <column name="level" value="L01"/>
@@ -3122,7 +3123,7 @@
             <column name="rule_id" value="155"/>
             <column name="br_id" value="FA-L01-00-0155"/>
             <column name="expression"
-                    value="speciesCode != null &amp;&amp; speciesCode.listId != null &amp;&amp; speciesCode.value != null &amp;&amp; !mdrService.isPresentInMDRList(speciesCode.listId, speciesCode.value )"/>
+                    value="speciesCode != null &amp;&amp; speciesCode.listId != null &amp;&amp; speciesCode.value != null &amp;&amp; !mdrService.isPresentInMDRList(speciesCode.listId, speciesCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check code. Must be existing in the list specified in attribute listID "/>
             <column name="message" value="Check code. Must be existing in the list specified in attribute listID "/>
             <column name="level" value="L01"/>
@@ -3246,7 +3247,7 @@
             <column name="rule_id" value="164"/>
             <column name="br_id" value="FA-L01-00-0164"/>
             <column name="expression"
-                    value="weighingMeansCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;WEIGHT_MEANS&quot; ,weighingMeansCode.value )"/>
+                    value="weighingMeansCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;WEIGHT_MEANS&quot; ,weighingMeansCode.value, creationDateOfMessage)"/>
             <column name="note" value="FA_Catch Weighing_MeansCode code must be present in MDR codelist WEIGHT_MEANS."/>
             <column name="message"
                     value="FA_Catch Weighing_MeansCode code must be present in MDR codelist WEIGHT_MEANS."/>
@@ -3292,7 +3293,7 @@
             <column name="rule_id" value="167"/>
             <column name="br_id" value="FA-L01-00-0167"/>
             <column name="expression"
-                    value="!isEmpty(sizeDistributionClassCode) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(&quot;FISH_SIZE_CLASS&quot; , sizeDistributionClassCode )"/>
+                    value="!isEmpty(sizeDistributionClassCode) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(&quot;FISH_SIZE_CLASS&quot;, sizeDistributionClassCode, creationDateOfMessage)"/>
             <column name="note" value="Si.e. BMS, LSC"/>
             <column name="message"
                     value="The size distribution ClassCode value is invalid."/>
@@ -3337,7 +3338,7 @@
             <column name="rule_id" value="170"/>
             <column name="br_id" value="FA-L02-00-0170"/>
             <column name="expression"
-                    value="categoryCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FA_BFT_SIZE_CATEGORY&quot; , categoryCode.value)"/>
+                    value="categoryCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FA_BFT_SIZE_CATEGORY&quot; , categoryCode.value, creationDateOfMessage)"/>
             <column name="note" value="If provided"/>
             <column name="message"
                     value="Specified Size_Distribution CategoryCode value must be present in FA_BFT_SIZE_CATEGORY list"/>
@@ -3368,7 +3369,7 @@
             <column name="rule_id" value="172"/>
             <column name="br_id" value="FA-L01-00-0172"/>
             <column name="expression"
-                    value="!isEmpty(appliedAAPProcessTypeCodes) &amp;&amp; !mdrService.isCodeTypeListIdPresentInMDRList(&quot;FLUX_PROCESS_TYPE&quot; , appliedAAPProcessTypeCodes) "/>
+                    value="!isEmpty(appliedAAPProcessTypeCodes) &amp;&amp; !mdrService.isCodeTypeListIdPresentInMDRList(&quot;FLUX_PROCESS_TYPE&quot; , appliedAAPProcessTypeCodes, creationDateOfMessage)"/>
             <column name="note" value="The value of the listID attribute must be on the list FLUX_PROCESS_TYPE."/>
             <column name="message" value="The listID for this processing type invalid."/>
             <column name="level" value="L01"/>
@@ -3382,7 +3383,7 @@
             <column name="rule_id" value="173"/>
             <column name="br_id" value="FA-L01-00-0173"/>
             <column name="expression"
-                    value="!isEmpty(appliedAAPProcessTypeCodes) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(appliedAAPProcessTypeCodes)"/>
+                    value="!isEmpty(appliedAAPProcessTypeCodes) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(appliedAAPProcessTypeCodes, creationDateOfMessage)"/>
             <column name="note" value="AppliedAAP_ Process TypeCode value must be present in FLUX_PROCESS_TYPE list"/>
             <column name="message"
                     value="AppliedAAP_ Process TypeCode value must be present in FLUX_PROCESS_TYPE list"/>
@@ -3461,7 +3462,7 @@
             <column name="rule_id" value="177"/>
             <column name="br_id" value="FA-L01-00-0177"/>
             <column name="expression"
-                    value="!mdrService.isCodeTypePresentInMDRList(&quot;FISH_PACKAGING&quot; , resultAAPProductPackagingTypeCode)"/>
+                    value="!mdrService.isCodeTypePresentInMDRList(&quot;FISH_PACKAGING&quot; , resultAAPProductPackagingTypeCode, creationDateOfMessage)"/>
             <column name="note" value="If provided"/>
             <column name="message"
                     value="The value of packaging TypeCode is invalid."/>
@@ -3686,7 +3687,7 @@
             <column name="br_id" value="FA-L03-00-0175"/>
             <column name="expression"
                     value="isEmpty(appliedAAPProcessConversionFactorNumber) &amp;&amp;
-                    !mdrService.combinationExistsInConversionFactorList(specifiedFLUXLocations, appliedAAPProcessTypeCodes, speciesCode)"/>
+                    !mdrService.combinationExistsInConversionFactorList(specifiedFLUXLocations, appliedAAPProcessTypeCodes, speciesCode, creationDateOfMessage)"/>
             <column name="note" value="Mandatory if EU or national conversion factor not available."/>
             <column name="message" value="Must be present if no conversion factor available for combination of FISH_PRESENTATION, FISH_PRESERVATION, Species and if applicable Area"/>
             <column name="level" value="L03"/>
@@ -3788,7 +3789,7 @@
             <column name="rule_id" value="126"/>
             <column name="br_id" value="FA-L01-00-0126"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FA_GEAR_CHARACTERISTIC&quot;, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FA_GEAR_CHARACTERISTIC&quot;, typeCode.value, creationDateOfMessage)"/>
             <column name="note"
                     value="Gear Characteristic typeCode value must be present in MDR list FA_GEAR_CHARACTERISTIC."/>
             <column name="message"
@@ -3892,7 +3893,7 @@
             <column name="rule_id" value="133"/>
             <column name="br_id" value="FA-L00-00-0133"/>
             <column name="expression"
-                    value="valueMeasure != null &amp;&amp;  !mdrService.isPresentInMDRList(&quot;FLUX_UNIT&quot;, valueMeasure.unitCode) "/>
+                    value="valueMeasure != null &amp;&amp;  !mdrService.isPresentInMDRList(&quot;FLUX_UNIT&quot;, valueMeasure.unitCode, creationDateOfMessage) "/>
             <column name="note" value="ValueMeasure unitCode value must be present in MDR list  FLUX_UNIT"/>
             <column name="message" value="Unexpected unit code for Measure."/>
             <column name="level" value="L00"/>
@@ -4221,7 +4222,7 @@
             <column name="rule_id" value="232"/>
             <column name="br_id" value="FA-L01-00-0232"/>
             <column name="expression"
-                    value="!isEmpty(typeCodes) &amp;&amp; !mdrService.isTypeCodeValuePresentInList(&quot;VESSEL_STORAGE_TYPE&quot;, typeCodes)"/>
+                    value="!isEmpty(typeCodes) &amp;&amp; !mdrService.isTypeCodeValuePresentInList(&quot;VESSEL_STORAGE_TYPE&quot;, typeCodes, creationDateOfMessage)"/>
             <column name="note" value="TypeCode(s) must be present in the listID attribute named VESSEL_STORAGE_TYPE"/>
             <column name="message"
                     value="The value of vessel storage characteristics TypeCode is invalid."/>
@@ -4263,7 +4264,7 @@
             <column name="rule_id" value="121"/>
             <column name="br_id" value="FA-L01-00-0121"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; typeCode.value != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;GEAR_TYPE&quot;, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; typeCode.value != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;GEAR_TYPE&quot;, typeCode.value, creationDateOfMessage)"/>
             <column name="note"
                     value="TypeCode(s) must be present in the list specified in the listID attribute named GEAR_TYPE"/>
             <column name="message"
@@ -4293,7 +4294,7 @@
             <column name="rule_id" value="134"/>
             <column name="br_id" value="FA-L01-00-0134"/>
             <column name="expression"
-                    value="!isEmpty(roleCodes) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(roleCodes)"/>
+                    value="!isEmpty(roleCodes) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(roleCodes, creationDateOfMessage)"/>
             <column name="note"
                     value="Check code. Must be existing in the list specified in attribute listID."/>
             <column name="message"
@@ -4338,7 +4339,7 @@
             <column name="rule_id" value="370"/>
             <column name="br_id" value="FA-L01-00-0370"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value, creationDateOfMessage)"/>
             <column name="note" value="FA_QueryParameter TypeCode@listID must be FA_QUERY_PARAMETER."/>
             <column name="message"
                     value="The value of the query parameter TypeCode is invalid."/>
@@ -4427,7 +4428,7 @@
             <column name="br_id" value="FA-L02-00-0373"/>
             <column name="expression"
                     value="valueID != null &amp;&amp; typeCode != null &amp;&amp; typeCode.value == &quot;VESSELID&quot; &amp;&amp;
-                    !mdrService.isAllSchemeIdsPresentInMDRList(&quot;FLUX_VESSEL_ID_TYPE&quot;, Arrays.asList(valueID))"/>
+                    !mdrService.isAllSchemeIdsPresentInMDRList(&quot;FLUX_VESSEL_ID_TYPE&quot;, Arrays.asList(valueID), creationDateOfMessage)"/>
             <column name="note"
                     value="FA_QueryParameter ValueID must be value from the list FLUX_VESSEL_ID if CodeType is VESSELID"/>
             <column name="message"
@@ -4600,7 +4601,7 @@
             <column name="rule_id" value="340"/>
             <column name="br_id" value="FA-L02-00-0340"/>
             <column name="expression"
-                    value="!isEmpty(flapDocumentIdTypes) &amp;&amp; !mdrService.isIdTypePresentInMDRList(&quot;FLAP_ID_TYPE&quot; , flapDocumentIdTypes) "/>
+                    value="!isEmpty(flapDocumentIdTypes) &amp;&amp; !mdrService.isIdTypePresentInMDRList(&quot;FLAP_ID_TYPE&quot; , flapDocumentIdTypes, creationDateOfMessage) "/>
             <column name="note" value="FLAPDocument ID Must have valid value from MDR list FLAP_ID_TYPE. "/>
             <column name="message" value="Fishing License, Authorization or Permit ID has an invalid schemeID. "/>
             <column name="level" value="L02"/>
@@ -4753,7 +4754,7 @@
             <column name="rule_id" value="137"/>
             <column name="br_id" value="FA-L01-00-0137"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FA_GEAR_PROBLEM&quot;, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FA_GEAR_PROBLEM&quot;, typeCode.value, creationDateOfMessage)"/>
             <column name="note"
                     value="TypeCode(s) must be present in the list specified in the listID attribute named FA_GEAR_PROBLEM"/>
             <column name="message"
@@ -4783,7 +4784,7 @@
             <column name="rule_id" value="142"/>
             <column name="br_id" value="FA-L01-00-0142"/>
             <column name="expression"
-                    value="!isEmpty(recoveryMeasureCodes) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(&quot;FA_GEAR_RECOVERY&quot;, recoveryMeasureCodes)"/>
+                    value="!isEmpty(recoveryMeasureCodes) &amp;&amp; !mdrService.isCodeTypePresentInMDRList(&quot;FA_GEAR_RECOVERY&quot;, recoveryMeasureCodes, creationDateOfMessage)"/>
             <column name="note" value="TypeCode(s) must be present in the listID attribute named FA_GEAR_RECOVERY"/>
             <column name="message" value="Recovery measure value is invalid."/>
             <column name="level" value="L01"/>
@@ -4876,7 +4877,7 @@
             <column name="rule_id" value="352"/>
             <column name="br_id" value="FA-L01-00-0352"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value, creationDateOfMessage)"/>
             <column name="note"
                     value="FA_Query TypeCode@listID must be existing in the list specified in attribute listID."/>
             <column name="message"
@@ -5517,7 +5518,7 @@
             <column name="rule_id" value="221"/>
             <column name="br_id" value="FA-L01-00-0221"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; !mdrService.isTypeCodeValuePresentInList(typeCode.listId, typeCode)"/>
+                    value="typeCode != null &amp;&amp; !mdrService.isTypeCodeValuePresentInList(typeCode.listId, typeCode, creationDateOfMessage)"/>
             <column name="note" value="TypeCode must be present in the list specified in the TypeCode's listId"/>
             <column name="message" value="The value of the FLUX characteristic TypeCode is invalid."/>
             <column name="level" value="L01"/>
@@ -5631,7 +5632,7 @@
             <column name="rule_id" value="229"/>
             <column name="br_id" value="FA-L00-00-0229"/>
             <column name="expression"
-                    value="typeCode != null &amp;&amp; mdrService.getDataTypeForMDRList(&quot;FA_CHARACTERISTIC&quot;, typeCode.value) == &quot;MEASURE&quot; &amp;&amp; valueMeasure != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FLUX_UNIT&quot;, valueMeasure.unitCode)"/>
+                    value="typeCode != null &amp;&amp; mdrService.getDataTypeForMDRList(&quot;FA_CHARACTERISTIC&quot;, typeCode.value) == &quot;MEASURE&quot; &amp;&amp; valueMeasure != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FLUX_UNIT&quot;, valueMeasure.unitCode, creationDateOfMessage)"/>
             <column name="note" value="Unit code must be defined in the list FLUX_UNIT"/>
             <column name="message" value="Unexpected unit code for Measure."/>
             <column name="level" value="L00"/>
@@ -5778,7 +5779,7 @@
             <column name="rule_id" value="383"/>
             <column name="br_id" value="FA-L00-00-0383"/>
             <column name="expression"
-                    value="referencedID !=null &amp;&amp; referencedID.schemeId != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FLUX_GP_MSG_ID&quot;, referencedID.schemeId)"/>
+                    value="referencedID !=null &amp;&amp; referencedID.schemeId != null &amp;&amp; !mdrService.isPresentInMDRList(&quot;FLUX_GP_MSG_ID&quot;, referencedID.schemeId, creationDateOfMessage)"/>
             <column name="note" value="Check attribute schemeID. Must be a valid value from code list FLUX_GP_MSG_ID."/>
             <column name="message" value="Response referenced ID has invalid schemeID."/>
             <column name="level" value="L00"/>
@@ -5805,7 +5806,7 @@
         <insert tableName="rule">
             <column name="rule_id" value="385"/>
             <column name="br_id" value="FA-L03-00-0385"/>
-            <column name="expression" value="referencedID != null &amp;&amp; stringEquals(&quot;UUID&quot;, referencedID.schemeId) &amp;&amp; !exchangeService.identificationRefExists(referencedID.value, &quot;FA_QUERY&quot;, &quot;FA_REPORT&quot;)"/>
+            <column name="expression" value="referencedID != null &amp;&amp; stringEquals(referencedID.schemeId, &quot;UUID&quot;) &amp;&amp; !exchangeService.identificationRefExists(referencedID.value, &quot;FA_QUERY&quot;, &quot;FA_REPORT&quot;)"/>
             <column name="note" value="referencedID value -- The identification must exist for a FLUXFAReportMessage or for a FLUXFAQuery message."/>
             <column name="message" value="The identification must exist for a FLUXFAReportMessage or for a FLUXFAQuery message."/>
             <column name="level" value="L03"/>
@@ -5847,7 +5848,7 @@
             <column name="rule_id" value="388"/>
             <column name="br_id" value="FA-L02-00-0388"/>
             <column name="expression"
-                    value="responseCode != null &amp;&amp; !mdrService.isPresentInMDRList(responseCode.listId, responseCode.value)"/>
+                    value="responseCode != null &amp;&amp; !mdrService.isPresentInMDRList(responseCode.listId, responseCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check responseCode. Must be existing in the list specified in attribute listID"/>
             <column name="message"
                     value="ResponseCode value is invalid."/>
@@ -6000,7 +6001,7 @@
             <column name="rule_id" valueNumeric="555"/>
             <column name="br_id" value="FA-L01-00-0555"/>
             <column name="expression"
-                    value="!isEmpty(validatorIDs) &amp;&amp; !mdrService.isIdTypePresentInMDRList(validatorIDs)  "/>
+                    value="!isEmpty(validatorIDs) &amp;&amp; !mdrService.isIdTypePresentInMDRList(validatorIDs, creationDateOfMessage)  "/>
             <column name="note" value="Check value. Must be value from the code list specified in schemeID."/>
             <column name="message" value="Validator ID value is invalid."/>
             <column name="level" value="L01"/>
@@ -6053,7 +6054,7 @@
         <insert tableName="rule">
             <column name="rule_id" value="399"/>
             <column name="br_id" value="FA-L01-00-0399"/>
-            <column name="expression" value="id != null &amp;&amp; !mdrService.isPresentInMDRList(id.schemeId, id.value)"/>
+            <column name="expression" value="id != null &amp;&amp; !mdrService.isPresentInMDRList(id.schemeId, id.value, creationDateOfMessage)"/>
             <column name="note"
                     value="Id -Check value. Code must be value of the specified code schemeId in listID. FA_BR."/>
             <column name="message"
@@ -6096,7 +6097,7 @@
             <column name="rule_id" value="402"/>
             <column name="br_id" value="FA-L01-00-0402"/>
             <column name="expression"
-                    value="levelCode != null &amp;&amp; !mdrService.isPresentInMDRList(levelCode.listId, levelCode.value)"/>
+                    value="levelCode != null &amp;&amp; !mdrService.isPresentInMDRList(levelCode.listId, levelCode.value, creationDateOfMessage)"/>
             <column name="note"
                     value="Check levelCode. Must be in the list specified in listID FLUX_GP_VALIDATION_LEVEL."/>
             <column name="message"
@@ -6126,7 +6127,7 @@
             <column name="rule_id" value="403"/>
             <column name="br_id" value="FA-L01-00-0403"/>
             <column name="expression"
-                    value="typeCode !=null &amp;&amp; (typeCode.listId != &quot;FLUX_GP_VALIDATION_TYPE&quot; || !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value))"/>
+                    value="typeCode !=null &amp;&amp; (typeCode.listId != &quot;FLUX_GP_VALIDATION_TYPE&quot; || !mdrService.isPresentInMDRList(typeCode.listId, typeCode.value, creationDateOfMessage))"/>
             <column name="note"
                     value="Check typeCode listID. Must be FLUX_GP_VALIDATION_TYPE and Check Code. Must be in the list specified in listID."/>
             <column name="message"
@@ -6144,7 +6145,7 @@
             <column name="rule_id" valueNumeric="406"/>
             <column name="br_id" value="FA-L01-00-0406"/>
             <column name="expression"
-                    value="typeCode !=null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId , typeCode.value)"/>
+                    value="typeCode !=null &amp;&amp; !mdrService.isPresentInMDRList(typeCode.listId , typeCode.value, creationDateOfMessage)"/>
             <column name="note" value="Check value of TypeCode. Must be in the list specified in listID."/>
             <column name="message" value="TypeCode value is invalid."/>
             <column name="level" value="L01"/>
@@ -6201,7 +6202,7 @@
             <column name="rule_id" value="277"/>
             <column name="br_id" value="FA-L02-00-0277"/>
             <column name="expression"
-                    value="!valueContainsAny(specifiedFACatchSpeciesCodes, &quot;BFT&quot;) &amp;&amp; (schemeIdContainsAny(specifiedFACatchDestinationFluxLocationIDs, &quot;FARM&quot;) || !mdrService.isPresentInMDRList(&quot;FARM&quot;, getValueForSchemeId(&quot;FARM&quot;, specifiedFACatchDestinationFluxLocationIDs)))"/>
+                    value="!valueContainsAny(specifiedFACatchSpeciesCodes, &quot;BFT&quot;) &amp;&amp; (schemeIdContainsAny(specifiedFACatchDestinationFluxLocationIDs, &quot;FARM&quot;) || !mdrService.isPresentInMDRList(&quot;FARM&quot;, getValueForSchemeId(&quot;FARM&quot;, specifiedFACatchDestinationFluxLocationIDs), creationDateOfMessage))"/>
             <column name="note"
                     value="SpecifiedFACatch DestinationFluxLocation ID's schemeId must be FARM and it's value must be in the MDR list if SpecifiedFACatch's SpeciesCode is BFT"/>
             <column name="message"
@@ -8770,7 +8771,7 @@
             <column name="rule_id" value="51"/>
             <column name="br_id" value="FA-L01-00-0051"/>
             <column name="expression"
-                    value="isFromFaReport &amp;&amp; !mdrService.isAllSchemeIdsPresentInMDRList(&quot;FLUX_VESSEL_ID_TYPE&quot;, ids)"/>
+                    value="isFromFaReport &amp;&amp; !mdrService.isAllSchemeIdsPresentInMDRList(&quot;FLUX_VESSEL_ID_TYPE&quot;, ids, creationDateOfMessage)"/>
             <column name="note" value="SchemeIDs must be present in the list FLUX_VESSEL_ID"/>
             <column name="message" value="Vessel ID has an invalid schemeID."/>
             <column name="level" value="L01"/>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <uvms.test.version>0.0.8</uvms.test.version>
 
         <usm4uvms.version>4.0.7</usm4uvms.version>
-        <uvms.config.version>4.0.0</uvms.config.version>
+        <uvms.config.version>4.0.1-SNAPSHOT</uvms.config.version>
         <uvms.common.version>3.0.20</uvms.common.version>
         <movement.model.version>4.0.7</movement.model.version>
         <exchange.model.version>4.0.17</exchange.model.version>
@@ -40,7 +40,7 @@
         <user.model.version>2.0.6</user.model.version>
 
         <activity.model.version>1.0.7</activity.model.version>
-        <mdr.model.version>1.0.2</mdr.model.version>
+        <mdr.model.version>1.0.4-SNAPSHOT</mdr.model.version>
         <subscription.model.version>1.3</subscription.model.version>
         <asset.model.version>4.0.11</asset.model.version>
         <audit.model.version>4.0.4</audit.model.version>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCache.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCache.java
@@ -10,24 +10,17 @@
 
 package eu.europa.ec.fisheries.uvms.rules.service.bean;
 
-import static eu.europa.ec.fisheries.uvms.activity.model.mapper.JAXBMarshaller.unmarshallTextMessage;
-import static java.util.Collections.emptyList;
-
-import javax.annotation.PostConstruct;
-import javax.ejb.EJB;
-import javax.ejb.Lock;
-import javax.ejb.LockType;
-import javax.ejb.Singleton;
-import javax.ejb.Startup;
-import javax.jms.TextMessage;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.base.Stopwatch;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import eu.europa.ec.fisheries.uvms.commons.date.DateUtils;
+import eu.europa.ec.fisheries.uvms.commons.message.api.MessageException;
+import eu.europa.ec.fisheries.uvms.commons.message.impl.JAXBUtils;
+import eu.europa.ec.fisheries.uvms.mdr.model.exception.MdrModelMarshallException;
 import eu.europa.ec.fisheries.uvms.mdr.model.mapper.MdrModuleMapper;
 import eu.europa.ec.fisheries.uvms.rules.message.constants.DataSourceQueue;
 import eu.europa.ec.fisheries.uvms.rules.message.consumer.RulesResponseConsumer;
@@ -36,11 +29,27 @@ import eu.europa.ec.fisheries.uvms.rules.service.constants.MDRAcronymType;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
 import un.unece.uncefact.data.standard.mdr.communication.MdrGetCodeListResponse;
+import un.unece.uncefact.data.standard.mdr.communication.MdrGetLastRefreshDateResponse;
 import un.unece.uncefact.data.standard.mdr.communication.ObjectRepresentation;
 
+import javax.annotation.PostConstruct;
+import javax.ejb.*;
+import javax.jms.JMSException;
+import javax.jms.TextMessage;
+import javax.xml.bind.JAXBException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static eu.europa.ec.fisheries.uvms.activity.model.mapper.JAXBMarshaller.unmarshallTextMessage;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 /**
- * @author Gregory Rinaldi
+ * @author Gregory Rinaldi, Andi Kovi
  */
 @Singleton
 @Startup
@@ -56,21 +65,83 @@ public class MDRCache {
     @EJB
     private RulesMessageProducer producer;
 
+    // This variable will store the Date last time this @cache was refreshed.
+    private Date cacheRefreshDate;
+
+    // This is the date that the last entity in mdr (module) was refreshed.
+    private Date mdrRefreshDate;
+
+    // This will avoid 70 date comparisons, otherwise unavoidable..
+    private boolean cacheDateChanged;
+
     @PostConstruct
-    public void init(){
+    public void init() {
         cache = CacheBuilder.newBuilder()
-                .refreshAfterWrite(24, TimeUnit.HOURS)
+                .refreshAfterWrite(10, TimeUnit.MINUTES)
                 .maximumSize(100)
                 .initialCapacity(80)
-                //.recordStats()
-                .build(
-                        new CacheLoader<MDRAcronymType, List<ObjectRepresentation>>() {
-                            @Override
-                            public List<ObjectRepresentation> load(MDRAcronymType acronymType) throws Exception {
-                                return mdrCodeListByAcronymType(acronymType);
-                            }
-                        }
+                .build(new CacheLoader<MDRAcronymType, List<ObjectRepresentation>>() {
+
+                           @Override
+                           public List<ObjectRepresentation> load(MDRAcronymType acronymType) {
+                               cacheRefreshDate = mdrRefreshDate;
+                               return mdrCodeListByAcronymType(acronymType);
+                           }
+
+                           @Override
+                           public ListenableFuture<List<ObjectRepresentation>> reload(final MDRAcronymType key, List<ObjectRepresentation> prevObjRappres) throws ExecutionException, InterruptedException {
+                               if (CollectionUtils.isEmpty(prevObjRappres) || cacheDateChanged) { // We also check for emptiness.
+                                   ListenableFutureTask<List<ObjectRepresentation>> task = ListenableFutureTask.create(new Callable<List<ObjectRepresentation>>() {
+                                       public List<ObjectRepresentation> call() {
+                                           return mdrCodeListByAcronymType(key);
+                                       }
+                                   });
+                                   Executors.newSingleThreadExecutor().execute(task);
+                                   task.get(); // Otherwise it creates problems with the upper calling code...
+                                   return task; // Wierd but this doesnt work : return Futures.immediateFuture(load(key));
+                               } else {
+                                   return Futures.immediateFuture(prevObjRappres);
+                               }
+                           }
+                       }
                 );
+    }
+
+    @AccessTimeout(value = 10, unit = MINUTES)
+    @Lock(LockType.WRITE)
+    public void loadAllMdrCodeLists() {
+        try {
+            populateMdrCacheDateAndCheckIfRefreshDateChanged();
+            ExecutorService executorService = Executors.newFixedThreadPool(5);
+            List<Callable<List<ObjectRepresentation>>> callableList = new ArrayList<>();
+            for (final MDRAcronymType type : MDRAcronymType.values()) {
+                callableList.add(new Callable<List<ObjectRepresentation>>() {
+                    @Override
+                    public List<ObjectRepresentation> call() {
+                        return getEntry(type);
+                    }
+                });
+            }
+            List<Future<List<ObjectRepresentation>>> futuresList = new ArrayList<>();
+            for (Callable<List<ObjectRepresentation>> callable : callableList) {
+                futuresList.add(executorService.submit(callable));
+            }
+            executorService.invokeAll(callableList);
+            executorService.shutdown();
+            // To make sure that the method loadAllMdrCodeLists() as a whole has executed all the Collables before exiting.
+            // awaitTermination doesn't stop as expected so wee need to call get() of Future here to make it wait for each task to finish!
+            for (Future<List<ObjectRepresentation>> future : futuresList) {
+                future.get();
+            }
+            if (cacheDateChanged) {
+                log.info("[INFO] MDR Cache Refresh was Needed and done already! Last time MDRs (CodeLists) were refreshed : [ " + mdrRefreshDate + " ]..");
+                cacheRefreshDate = new Date(mdrRefreshDate.getTime());
+                log.debug(cache.stats().toString());
+                log.info("MDRCache size: " + cache.size());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error(e.getMessage(), e);
+        }
     }
 
     @Lock(LockType.READ)
@@ -80,12 +151,10 @@ public class MDRCache {
         if (acronymType != null) {
             result = cache.getUnchecked(acronymType);
         }
-
         long elapsed = stopwatch.elapsed(TimeUnit.SECONDS);
-        if (elapsed > 0.25){
+        if (elapsed > 0.5) {
             log.info("Loading " + acronymType + " took " + stopwatch);
         }
-
         return result;
     }
 
@@ -93,13 +162,55 @@ public class MDRCache {
     private List<ObjectRepresentation> mdrCodeListByAcronymType(MDRAcronymType acronym) {
         String request = MdrModuleMapper.createFluxMdrGetCodeListRequest(acronym.name());
         String corrId = producer.sendDataSourceMessage(request, DataSourceQueue.MDR_EVENT);
-        long timeoutMillis = 30 * 60 * 1000;
-        TextMessage message = consumer.getMessage(corrId, TextMessage.class, timeoutMillis);
+        TextMessage message = consumer.getMessage(corrId, TextMessage.class, 300000L);
         if (message != null) {
             MdrGetCodeListResponse response = unmarshallTextMessage(message.getText(), MdrGetCodeListResponse.class);
             return response.getDataSets();
         }
         return new ArrayList<>();
+    }
+
+    /**
+     * Checks if the refresh date from mdr module has changed.
+     * If it has changed sets cacheDateChanged=true; and refreshed the mdrRefreshDate with the new date.
+     */
+    private void populateMdrCacheDateAndCheckIfRefreshDateChanged() {
+        cacheDateChanged = false;
+        // TODO : optimize for : if at least 5 minutes have passed...
+        try {
+            Date mdrDate = getLastTimeMdrWasRefreshedFromMdrModule();
+            if (mdrRefreshDate == null || !mdrDate.equals(mdrRefreshDate)) { // This means we have a new date from MDR module..
+                mdrRefreshDate = mdrDate;
+                cacheDateChanged = true;
+            }
+        } catch (MessageException e) {
+            log.error("[ERROR] Couldn't populate MDR Refresh date.. MDR Module is deployed?");
+        }
+    }
+
+    /**
+     * Calls MDR module to get the latest date the MDR lists werisPresentInMDRListe refreshed.
+     *
+     * @return
+     * @throws MessageException
+     */
+    private Date getLastTimeMdrWasRefreshedFromMdrModule() throws MessageException {
+        try {
+            String corrId = producer.sendDataSourceMessage(MdrModuleMapper.createMdrGetLastRefreshDateRequest(), DataSourceQueue.MDR_EVENT);
+            TextMessage message = consumer.getMessage(corrId, TextMessage.class, 30000L);
+            if (message != null) {
+                MdrGetLastRefreshDateResponse response = JAXBUtils.unMarshallMessage(message.getText(), MdrGetLastRefreshDateResponse.class);
+                return response.getLastRefreshDate() != null ? DateUtils.xmlGregorianCalendarToDate(response.getLastRefreshDate()) : null;
+            }
+            throw new MessageException("[FATAL-ERROR] Couldn't get LastRefreshDate from MDR Module! Mdr is deployed?");
+        } catch (MdrModelMarshallException | JAXBException | JMSException e) {
+            throw new MessageException("[FATAL-ERROR] Couldn't get LastRefreshDate from MDR Module! Mdr is deployed?");
+        }
+    }
+
+    private static long getDifferenceBetweenDates(Date firstDate, Date secondDate, TimeUnit timeUnit) {
+        long diffInMillies = Math.abs(secondDate.getTime() - firstDate.getTime());
+        return TimeUnit.DAYS.convert(diffInMillies, timeUnit);
     }
 
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCacheRuleService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCacheRuleService.java
@@ -28,57 +28,29 @@ public interface MDRCacheRuleService {
 
     EnrichedBRMessage getErrorMessageForBrId(String brId);
 
-    @Deprecated
-    boolean isPresentInMDRList(String listName, String codeValue);
-
     boolean isPresentInMDRList(String listName, String codeValue, DateTime creationDateOfMessage);
-
-    @Deprecated
-    boolean isTypeCodeValuePresentInList(String listName, List<CodeType> typeCodes);
 
     boolean isTypeCodeValuePresentInList(String listName, List<CodeType> typeCodes, DateTime creationDateOfMessage);
 
-    @Deprecated
-    boolean isTypeCodeValuePresentInList(String listName, CodeType typeCode);
-
     boolean isTypeCodeValuePresentInList(String listName, CodeType typeCode, DateTime creationDateOfMessage);
-
-    @Deprecated
-    boolean isCodeTypePresentInMDRList(List<CodeType> valuesToMatch);
 
     boolean isCodeTypePresentInMDRList(List<CodeType> valuesToMatch, DateTime creationDateOfMessage);
 
-    @Deprecated
-    boolean isCodeTypePresentInMDRList(String listName, List<CodeType> valuesToMatch);
-
     boolean isCodeTypePresentInMDRList(String listName, List<CodeType> valuesToMatch, DateTime creationDateOfMessage);
 
-    boolean isCodeTypeListIdPresentInMDRList(String listName, List<CodeType> valuesToMatch);
-
-    @Deprecated
-    boolean isIdTypePresentInMDRList(String listName, List<IdType> valuesToMatch);
+    boolean isCodeTypeListIdPresentInMDRList(String listName, List<CodeType> valuesToMatch, DateTime creationDateOfMessage);
 
     boolean isIdTypePresentInMDRList(String listName, List<IdType> valuesToMatch, DateTime creationDateOfMessage);
 
-    @Deprecated
-    boolean isIdTypePresentInMDRList(List<IdType> ids);
-
     boolean isIdTypePresentInMDRList(List<IdType> ids, DateTime creationDateOfMessage);
-
-    @Deprecated
-    boolean isIdTypePresentInMDRList(IdType id);
 
     boolean isIdTypePresentInMDRList(IdType id, DateTime creationDateOfMessage);
 
-    boolean isSchemeIdPresentInMDRList(String listName, IdType idType);
-
     String getDataTypeForMDRList(String listName, String codeValue);
 
-    String getValueForListId(String listId, List<CodeType> typeCodes);
+    boolean isAllSchemeIdsPresentInMDRList(String listName, List<IdType> idTypes, DateTime creationDateOfMessage);
 
-    boolean isAllSchemeIdsPresentInMDRList(String listName, List<IdType> idTypes);
-
-    boolean combinationExistsInConversionFactorList(List<FLUXLocation> specifiedFLUXLocations,  List<CodeType> appliedAAPProcessTypeCodes, CodeType speciesCode);
+    boolean combinationExistsInConversionFactorList(List<FLUXLocation> specifiedFLUXLocations,  List<CodeType> appliedAAPProcessTypeCodes, CodeType speciesCode, DateTime creationDateOfMessage);
 
     boolean isNotMostPreciseFAOArea(IdType id, DateTime creationDateOfMessage);
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCacheServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCacheServiceBean.java
@@ -10,24 +10,6 @@
 
 package eu.europa.ec.fisheries.uvms.rules.service.bean;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
-import javax.ejb.AccessTimeout;
-import javax.ejb.EJB;
-import javax.ejb.Lock;
-import javax.ejb.LockType;
-import javax.ejb.Singleton;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -47,6 +29,11 @@ import un.unece.uncefact.data.standard.mdr.communication.ObjectRepresentation;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXLocation;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
+import javax.ejb.*;
+import java.util.*;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 @Singleton
 @Slf4j
 public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService {
@@ -56,47 +43,19 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
 
     private Map<String, EnrichedBRMessage> errorMessages;
 
-    @AccessTimeout(value = 30, unit = MINUTES)
-    @Lock(LockType.WRITE)
     public void loadMDRCache() {
-        try {
-            ExecutorService executorService = Executors.newFixedThreadPool(5);
-            List<Callable<List<ObjectRepresentation>>> myCallableList = new ArrayList<>();
-            for (final MDRAcronymType type : MDRAcronymType.values()){
-                if ((type != MDRAcronymType.FA_BR_DEF)
-                        && (type != MDRAcronymType.SALE_BR_DEF)) {
-                    myCallableList.add(new Callable<List<ObjectRepresentation>>() {
-                        @Override
-                        public List<ObjectRepresentation> call() {
-                            return cache.getEntry(type);
-                        }
-                    });
-                }
-            }
-            executorService.invokeAll(myCallableList);
-            executorService.shutdown();
-
-            // Blocks until all tasks have completed execution after a shutdown request, or the timeout occurs,
-            // or the current thread is interrupted, whichever happens first.
-            executorService.awaitTermination(30, TimeUnit.MINUTES);
-
-        } catch (InterruptedException e) {
-            log.error(e.getMessage(), e);
-        }
-        log.debug(cache.getCache().stats().toString());
-        log.info("MDRCache size: " + cache.getCache().asMap().size());
+        cache.loadAllMdrCodeLists();
     }
 
     @Override
     @AccessTimeout(value = 180, unit = SECONDS)
     @Lock(LockType.READ)
-    public EnrichedBRMessage getErrorMessageForBrId(String brId){
+    public EnrichedBRMessage getErrorMessageForBrId(String brId) {
         return errorMessages.get(brId);
     }
 
     /**
      * This function maps all the error messages to the ones defined in MDR;
-     *
      */
     @AccessTimeout(value = 180, unit = SECONDS)
     @Lock(LockType.READ)
@@ -105,7 +64,7 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
             return;
         }
         errorMessages = new HashMap<>();
-        final List<ObjectRepresentation> objRapprList = new ArrayList<ObjectRepresentation>(){{
+        final List<ObjectRepresentation> objRapprList = new ArrayList<ObjectRepresentation>() {{
             addAll(cache.getEntry(MDRAcronymType.FA_BR_DEF));
             addAll(cache.getEntry(MDRAcronymType.SALE_BR_DEF));
         }};
@@ -120,27 +79,18 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
 
             for (ColumnDataType field : objectRepr.getFields()) {
                 final String columnName = field.getColumnName();
-                if(MESSAGE_COLUMN.equals(columnName)){
+                if (MESSAGE_COLUMN.equals(columnName)) {
                     errorMessage = field.getColumnValue();
                 }
-                if(BR_ID_COLUMN.equals(columnName)){
+                if (BR_ID_COLUMN.equals(columnName)) {
                     brId = field.getColumnValue();
                 }
-                if(BR_NOTE_COLUMN.equals(columnName)){
+                if (BR_NOTE_COLUMN.equals(columnName)) {
                     note = field.getColumnValue();
                 }
             }
-            errorMessages.put(brId,new EnrichedBRMessage(note, errorMessage));
+            errorMessages.put(brId, new EnrichedBRMessage(note, errorMessage));
         }
-    }
-
-
-    @Deprecated
-    @Override
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isPresentInMDRList(String listName, String codeValue) {
-        return isPresentInMDRList(listName, codeValue, DateTime.now());
     }
 
     /**
@@ -153,45 +103,14 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isPresentInMDRList(String listName, String codeValue, DateTime creationDateOfMessage) {
+    public boolean isPresentInMDRList(String listName, String codeValue, DateTime validityDate) {
         MDRAcronymType mdrAcronymType = EnumUtils.getEnum(MDRAcronymType.class, listName);
         if (mdrAcronymType == null) {
             return false;
         }
-        List<String> values = getValues(mdrAcronymType, creationDateOfMessage);
+        List<String> values = getValues(mdrAcronymType, validityDate);
         return CollectionUtils.isNotEmpty(values) && values.contains(codeValue);
     }
-
-    private List<String> getList(List<ObjectRepresentation> entry, DateTime date) {
-        List<String> codeColumnValues = new ArrayList<>();
-        if (CollectionUtils.isEmpty(entry)) {
-            return Collections.emptyList();
-        }
-        for (ObjectRepresentation representation : entry) {
-            List<ColumnDataType> columnDataTypes = representation.getFields();
-            if (CollectionUtils.isEmpty(columnDataTypes)) {
-                continue;
-            }
-            Optional<String> code = ObjectRepresentationHelper.getValueOfColumn("code", representation);
-            Optional<String> startDate = ObjectRepresentationHelper.getValueOfColumn("startDate", representation);
-            Optional<String> endDate = ObjectRepresentationHelper.getValueOfColumn("endDate", representation);
-            if (code.isPresent() && startDate.isPresent() && endDate.isPresent()
-                    && date.isAfter(ObjectRepresentationHelper.parseDate(startDate.get()))
-                    && date.isBefore(ObjectRepresentationHelper.parseDate(endDate.get()))) {
-                codeColumnValues.add(code.get());
-            }
-        }
-        return codeColumnValues;
-    }
-
-    @Deprecated
-    @Override
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isCodeTypePresentInMDRList(List<CodeType> valuesToMatch) {
-        return isCodeTypePresentInMDRList(valuesToMatch, DateTime.now());
-    }
-
 
     /**
      * This function checks that all the CodeType values passed to the function exist in MDR code list defined by its listId
@@ -202,7 +121,7 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isCodeTypePresentInMDRList(List<CodeType> valuesToMatch, DateTime creationDateOfMessage) {
+    public boolean isCodeTypePresentInMDRList(List<CodeType> valuesToMatch, DateTime validityDate) {
         if (CollectionUtils.isEmpty(valuesToMatch)) {
             return false;
         }
@@ -214,7 +133,7 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
             if (anEnum == null) {
                 return false;
             }
-            List<String> codeListValues = getValues(anEnum, creationDateOfMessage);
+            List<String> codeListValues = getValues(anEnum, validityDate);
             if (!codeListValues.contains(codeType.getValue())) {
                 return false;
             }
@@ -222,18 +141,6 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         return true;
     }
 
-    private List<String> getValues(MDRAcronymType anEnum, DateTime date) {
-        List<ObjectRepresentation> entry = cache.getEntry(anEnum);
-        return getList(entry, date);
-    }
-
-    @Override
-    @Deprecated
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isIdTypePresentInMDRList(String listName, List<IdType> valuesToMatch) {
-        return isIdTypePresentInMDRList(listName, valuesToMatch, DateTime.now());
-    }
 
     /**
      * This function checks that all the IdType values passed to the function exist in MDR code list or not
@@ -245,12 +152,12 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isIdTypePresentInMDRList(String listName, List<IdType> valuesToMatch, DateTime creationDateOfMessage) {
+    public boolean isIdTypePresentInMDRList(String listName, List<IdType> valuesToMatch, DateTime validityDate) {
         MDRAcronymType anEnum = EnumUtils.getEnum(MDRAcronymType.class, listName);
         if (anEnum == null) {
             return false;
         }
-        List<String> codeListValues = getValues(anEnum, creationDateOfMessage);
+        List<String> codeListValues = getValues(anEnum, validityDate);
         if (CollectionUtils.isEmpty(valuesToMatch) || CollectionUtils.isEmpty(codeListValues)) {
             return false;
         }
@@ -259,14 +166,6 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
                 return false;
         }
         return true;
-    }
-
-    @Deprecated
-    @Override
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isCodeTypePresentInMDRList(String listName, List<CodeType> valuesToMatch) {
-        return isCodeTypePresentInMDRList(listName, valuesToMatch, DateTime.now());
     }
 
     /**
@@ -279,12 +178,12 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isCodeTypePresentInMDRList(String listName, List<CodeType> valuesToMatch, DateTime creationDateOfMessage) {
+    public boolean isCodeTypePresentInMDRList(String listName, List<CodeType> valuesToMatch, DateTime validityDate) {
         MDRAcronymType anEnum = EnumUtils.getEnum(MDRAcronymType.class, listName);
         if (anEnum == null) {
             return false;
         }
-        List<String> codeListValues = getValues(anEnum, creationDateOfMessage);
+        List<String> codeListValues = getValues(anEnum, validityDate);
         if (CollectionUtils.isEmpty(valuesToMatch) || CollectionUtils.isEmpty(codeListValues)) {
             return false;
         }
@@ -296,14 +195,15 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         return true;
     }
 
+    @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isCodeTypeListIdPresentInMDRList(String listName, List<CodeType> valuesToMatch) {
+    public boolean isCodeTypeListIdPresentInMDRList(String listName, List<CodeType> valuesToMatch, DateTime validityDate) {
         MDRAcronymType anEnum = EnumUtils.getEnum(MDRAcronymType.class, listName);
         if (anEnum == null) {
             return false;
         }
-        List<String> codeListValues = getValues(anEnum, DateTime.now());
+        List<String> codeListValues = getValues(anEnum, validityDate);
         if (CollectionUtils.isEmpty(valuesToMatch) || CollectionUtils.isEmpty(codeListValues)) {
             return false;
         }
@@ -315,34 +215,18 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     }
 
     @Override
-    @Deprecated
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isIdTypePresentInMDRList(List<IdType> ids) {
-        return isIdTypePresentInMDRList(ids, DateTime.now());
-    }
-
-    @Override
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isIdTypePresentInMDRList(List<IdType> ids, DateTime creationDateOfMessage) {
+    public boolean isIdTypePresentInMDRList(List<IdType> ids, DateTime validityDate) {
         if (CollectionUtils.isEmpty(ids)) {
             return false;
         }
         for (IdType idType : ids) {
-            if (!isIdTypePresentInMDRList(idType, creationDateOfMessage)) {
+            if (!isIdTypePresentInMDRList(idType, validityDate)) {
                 return false;
             }
         }
         return true;
-    }
-
-    @Override
-    @Deprecated
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isIdTypePresentInMDRList(IdType id) {
-        return isIdTypePresentInMDRList(id, DateTime.now());
     }
 
     /**
@@ -372,12 +256,12 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isAllSchemeIdsPresentInMDRList(String listName, List<IdType> idTypes) {
-        if (StringUtils.isBlank(listName) || isEmpty(idTypes)) {
+    public boolean isAllSchemeIdsPresentInMDRList(String listName, List<IdType> idTypes, DateTime creationDateOfMessage) {
+        if (StringUtils.isBlank(listName) || CollectionUtils.isEmpty(idTypes)) {
             return false;
         }
         for (IdType idType : idTypes) {
-            if (!isSchemeIdPresentInMDRList(listName, idType)) {
+            if (!isSchemeIdPresentInMDRList(listName, idType, creationDateOfMessage)) {
                 return false;
             }
         }
@@ -387,38 +271,38 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean combinationExistsInConversionFactorList(List<FLUXLocation> specifiedFLUXLocations, List<CodeType> appliedAAPProcessTypeCodes, CodeType speciesCode) {
+    public boolean combinationExistsInConversionFactorList(List<FLUXLocation> specifiedFLUXLocations, List<CodeType> appliedAAPProcessTypeCodes, CodeType speciesCode, DateTime validityDate) {
         // clean lists from nulls
         Iterables.removeIf(specifiedFLUXLocations, Predicates.isNull());
         Iterables.removeIf(appliedAAPProcessTypeCodes, Predicates.isNull());
         // country column
         String country = StringUtils.EMPTY;
-        if(CollectionUtils.isNotEmpty(specifiedFLUXLocations)){
-            for(FLUXLocation location : specifiedFLUXLocations){
+        if (CollectionUtils.isNotEmpty(specifiedFLUXLocations)) {
+            for (FLUXLocation location : specifiedFLUXLocations) {
                 final IDType locId = location.getID();
-                if(locId != null && ("TERRITORY".equals(locId.getSchemeID()) || "MANAGEMENT_AREA".equals(locId.getSchemeID()))){
+                if (locId != null && ("TERRITORY".equals(locId.getSchemeID()) || "MANAGEMENT_AREA".equals(locId.getSchemeID()))) {
                     country = locId.getValue();
                 }
             }
         }
-        if(isPresentInMDRList("MEMBER_STATE", country)){
+        if (isPresentInMDRList("MEMBER_STATE", country, validityDate)) {
             country = "XEU";
         }
         // presentation, state columns
         String presentation = StringUtils.EMPTY;
         String state = StringUtils.EMPTY;
-        if(CollectionUtils.isNotEmpty(appliedAAPProcessTypeCodes)){
-            for(CodeType presPreserv : appliedAAPProcessTypeCodes){
-                if("FISH_PRESENTATION".equals(presPreserv.getListId())){
+        if (CollectionUtils.isNotEmpty(appliedAAPProcessTypeCodes)) {
+            for (CodeType presPreserv : appliedAAPProcessTypeCodes) {
+                if ("FISH_PRESENTATION".equals(presPreserv.getListId())) {
                     presentation = presPreserv.getValue();
                 }
-                if("FISH_PRESERVATION".equals(presPreserv.getListId())){
+                if ("FISH_PRESERVATION".equals(presPreserv.getListId())) {
                     state = presPreserv.getValue();
                 }
             }
         }
         List<ObjectRepresentation> finalList = null;
-        if(!(StringUtils.isBlank(country) || StringUtils.isBlank(presentation) || StringUtils.isBlank(state))){
+        if (!(StringUtils.isBlank(country) || StringUtils.isBlank(presentation) || StringUtils.isBlank(state))) {
             List<ObjectRepresentation> entry = cache.getEntry(MDRAcronymType.CONVERSION_FACTOR);
             List<ObjectRepresentation> filtered_1_list = filterEntriesByColumn(entry, "placesCode", country);
             List<ObjectRepresentation> filtered_2_list = filterEntriesByColumn(filtered_1_list, "species", speciesCode != null ? speciesCode.getValue() : StringUtils.EMPTY);
@@ -428,19 +312,24 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         return CollectionUtils.isNotEmpty(finalList);
     }
 
-    private List<ObjectRepresentation> filterEntriesByColumn(List<ObjectRepresentation> entries, String columnName, String columnValue){
-        if(CollectionUtils.isEmpty(entries) || StringUtils.isEmpty(columnValue) || StringUtils.isEmpty(columnName)){
+    private List<ObjectRepresentation> filterEntriesByColumn(List<ObjectRepresentation> entries, String columnName, String columnValue) {
+        if (CollectionUtils.isEmpty(entries) || StringUtils.isEmpty(columnValue) || StringUtils.isEmpty(columnName)) {
             return entries;
         }
         List<ObjectRepresentation> matchingList = new ArrayList<>();
-        for(ObjectRepresentation entry : entries){
-            for(ColumnDataType field : entry.getFields()){
-                if(field.getColumnName().equals(columnName) && field.getColumnValue().equals(columnValue)){
+        for (ObjectRepresentation entry : entries) {
+            for (ColumnDataType field : entry.getFields()) {
+                if (field.getColumnName().equals(columnName) && field.getColumnValue().equals(columnValue)) {
                     matchingList.add(entry);
                 }
             }
         }
         return matchingList;
+    }
+
+    private List<String> getValues(MDRAcronymType anEnum, DateTime date) {
+        List<ObjectRepresentation> entry = cache.getEntry(anEnum);
+        return getList(entry, date);
     }
 
     /**
@@ -461,7 +350,6 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         boolean valueFound = false;
         if (CollectionUtils.isNotEmpty(representations)) {
             for (ObjectRepresentation representation : representations) {
-
                 List<ColumnDataType> columnDataTypes = representation.getFields();
                 if (CollectionUtils.isEmpty(columnDataTypes)) {
                     continue;
@@ -484,35 +372,13 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         return StringUtils.EMPTY;
     }
 
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isSchemeIdPresentInMDRList(String listName, IdType idType) {
-        return idType != null && !StringUtils.isBlank(idType.getSchemeId()) && isPresentInMDRList(listName, idType.getSchemeId());
-    }
-
-    private boolean isEmpty(List<?> list) {
-        return CollectionUtils.isEmpty(list);
-    }
-
-    @Deprecated
-    @Override
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isTypeCodeValuePresentInList(String listName, CodeType typeCode) {
-        return isTypeCodeValuePresentInList(listName, typeCode, DateTime.now());
+    private boolean isSchemeIdPresentInMDRList(String listName, IdType idType, DateTime creationDateOfMessage) {
+        return idType != null && !StringUtils.isBlank(idType.getSchemeId()) && isPresentInMDRList(listName, idType.getSchemeId(), creationDateOfMessage);
     }
 
     @Override
     public boolean isTypeCodeValuePresentInList(String listName, CodeType typeCode, DateTime creationDateOfMessage) {
         return isTypeCodeValuePresentInList(listName, Collections.singletonList(typeCode), creationDateOfMessage);
-    }
-
-    @Deprecated
-    @Override
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isTypeCodeValuePresentInList(String listName, List<CodeType> typeCodes) {
-        return isTypeCodeValuePresentInList(listName, typeCodes, DateTime.now());
     }
 
     @Override
@@ -523,16 +389,34 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         return typeCodeValue != null && isPresentInMDRList(listName, typeCodeValue, creationDateOfMessage);
     }
 
-    @Override
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public String getValueForListId(String listId, List<CodeType> typeCodes) {
+    private List<String> getList(List<ObjectRepresentation> entry, DateTime date) {
+        List<String> codeColumnValues = new ArrayList<>();
+        if (CollectionUtils.isEmpty(entry) || date == null) {
+            return Collections.emptyList();
+        }
+        for (ObjectRepresentation representation : entry) {
+            List<ColumnDataType> columnDataTypes = representation.getFields();
+            if (CollectionUtils.isEmpty(columnDataTypes)) {
+                continue;
+            }
+            Optional<String> code = ObjectRepresentationHelper.getValueOfColumn("code", representation);
+            Optional<String> startDate = ObjectRepresentationHelper.getValueOfColumn("startDate", representation);
+            Optional<String> endDate = ObjectRepresentationHelper.getValueOfColumn("endDate", representation);
+            if (code.isPresent() && startDate.isPresent() && endDate.isPresent()
+                    && date.isAfter(ObjectRepresentationHelper.parseDate(startDate.get()))
+                    && date.isBefore(ObjectRepresentationHelper.parseDate(endDate.get()))) {
+                codeColumnValues.add(code.get());
+            }
+        }
+        return codeColumnValues;
+    }
+
+    private String getValueForListId(String listId, List<CodeType> typeCodes) {
         if (StringUtils.isBlank(listId) || CollectionUtils.isEmpty(typeCodes)) {
             return null;
         }
         for (CodeType typeCode : typeCodes) {
             String typeCodeListId = typeCode.getListId();
-
             if (StringUtils.isNotBlank(typeCodeListId) && typeCodeListId.equals(listId)) {
                 return typeCode.getValue();
             }
@@ -545,8 +429,8 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @AccessTimeout(value = 180, unit = SECONDS)
     public boolean isNotMostPreciseFAOArea(IdType id, DateTime creationDateOfMessage) {
         List<ObjectRepresentation> faoAreas = cache.getEntry(MDRAcronymType.FAO_AREA);
-        return !ObjectRepresentationHelper.doesObjectRepresentationExistWithTheGivenCodeAndWithTheGivenValueForTheGivenColumn
-                (id.getValue(), "terminalInd", "1", faoAreas, creationDateOfMessage);
+        return !ObjectRepresentationHelper
+                .doesObjectRepresentationExistWithTheGivenCodeAndWithTheGivenValueForTheGivenColumn(id.getValue(), "terminalInd", "1", faoAreas, creationDateOfMessage);
     }
 
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCacheServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/MDRCacheServiceBean.java
@@ -144,21 +144,13 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     @Override
     @Lock(LockType.READ)
     @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isCodeTypePresentInMDRList(CodeType valueToMatch, DateTime creationDateOfMessage) {
-        return isCodeTypePresentInMDRList(Arrays.asList(valueToMatch), creationDateOfMessage);
+    public boolean isCodeTypePresentInMDRList(CodeType valueToMatch, DateTime validityDate) {
+        return isCodeTypePresentInMDRList(Arrays.asList(valueToMatch), validityDate);
     }
 
     private List<String> getValues(MDRAcronymType anEnum, DateTime date) {
         List<ObjectRepresentation> entry = cache.getEntry(anEnum);
         return getList(entry, date);
-    }
-
-    @Override
-    @Deprecated
-    @Lock(LockType.READ)
-    @AccessTimeout(value = 180, unit = SECONDS)
-    public boolean isIdTypePresentInMDRList(String listName, List<IdType> valuesToMatch) {
-        return isIdTypePresentInMDRList(listName, valuesToMatch, DateTime.now());
     }
 
     /**
@@ -346,11 +338,6 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         return matchingList;
     }
 
-    private List<String> getValues(MDRAcronymType anEnum, DateTime date) {
-        List<ObjectRepresentation> entry = cache.getEntry(anEnum);
-        return getList(entry, date);
-    }
-
     /**
      * This method gets value from DataType Column of MDR list for the matching record. Record will be matched with CODE column
      *
@@ -391,10 +378,6 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
         return StringUtils.EMPTY;
     }
 
-    private boolean isSchemeIdPresentInMDRList(String listName, IdType idType, DateTime creationDateOfMessage) {
-        return idType != null && !StringUtils.isBlank(idType.getSchemeId()) && isPresentInMDRList(listName, idType.getSchemeId(), creationDateOfMessage);
-    }
-
     @Override
     public boolean isTypeCodeValuePresentInList(String listName, CodeType typeCode, DateTime creationDateOfMessage) {
         return isTypeCodeValuePresentInList(listName, Collections.singletonList(typeCode), creationDateOfMessage);
@@ -406,6 +389,10 @@ public class MDRCacheServiceBean implements MDRCacheService, MDRCacheRuleService
     public boolean isTypeCodeValuePresentInList(String listName, List<CodeType> typeCodes, DateTime creationDateOfMessage) {
         String typeCodeValue = getValueForListId(listName, typeCodes);
         return typeCodeValue != null && isPresentInMDRList(listName, typeCodeValue, creationDateOfMessage);
+    }
+
+    private boolean isSchemeIdPresentInMDRList(String listName, IdType idType, DateTime creationDateOfMessage) {
+        return idType != null && !StringUtils.isBlank(idType.getSchemeId()) && isPresentInMDRList(listName, idType.getSchemeId(), creationDateOfMessage);
     }
 
     private List<String> getList(List<ObjectRepresentation> entry, DateTime date) {

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/RulesMessageServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/RulesMessageServiceBean.java
@@ -713,8 +713,10 @@ public class RulesMessageServiceBean implements RulesMessageService {
                 uuidString = idType.getValue();
                 String schemeID = idType.getSchemeID();
                 if ("UUID".equals(schemeID)){
-                    UUID.fromString(uuidString);
-                    uuidIsCorrect = true;
+                    uuidIsCorrect = UUID.fromString(uuidString).equals(uuidString);
+                }
+                if(!uuidIsCorrect){
+                    log.debug("[WARN] The given UUID is not in a correct format {}", uuidString);
                 }
             }
         } catch (IllegalArgumentException exception){

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/TemplateEngine.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/TemplateEngine.java
@@ -115,9 +115,9 @@ public class TemplateEngine {
     }
 
     public List<RuleError> checkRulesAreLoaded(int retries) {
-        AbstractFact faRepFact = getMockedFact();
-        ruleEvaluator.validateFacts(Collections.singletonList(faRepFact));
-        if (CollectionUtils.isEmpty(faRepFact.getErrors())) { // Means rules were not loaded, otherwise we'd have errors here.
+        AbstractFact fishTripFact = getMockedFact();
+        ruleEvaluator.validateFacts(Collections.singletonList(fishTripFact));
+        if (CollectionUtils.isEmpty(fishTripFact.getErrors())) { // Means rules were not loaded, otherwise we'd have errors here.
             if (retries < 5) {
                 initialize();
                 retries++;
@@ -128,7 +128,7 @@ public class TemplateEngine {
             }
         }
 
-        return faRepFact.getErrors();
+        return fishTripFact.getErrors();
     }
 
     private AbstractFact getMockedFact() {

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBean.java
@@ -253,11 +253,11 @@ public class SalesRulesServiceBean implements SalesRulesService {
 
         switch (typeCode.getValue()){
             case "ROLE":
-                return !mdrService.isPresentInMDRList("FLUX_SALES_QUERY_PARAM_ROLE", valueCode.getValue());
+                return !mdrService.isPresentInMDRList("FLUX_SALES_QUERY_PARAM_ROLE", valueCode.getValue(), DateTime.now());
             case "FLAG":
-                return !mdrService.isPresentInMDRList("TERRITORY", valueCode.getValue());
+                return !mdrService.isPresentInMDRList("TERRITORY", valueCode.getValue(), DateTime.now());
             case "PLACE":
-                return !mdrService.isPresentInMDRList("LOCATION", valueCode.getValue());
+                return !mdrService.isPresentInMDRList("LOCATION", valueCode.getValue(), DateTime.now());
             default:
                 return true;
         }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/BusinessObjectFactory.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/BusinessObjectFactory.java
@@ -15,7 +15,7 @@ package eu.europa.ec.fisheries.uvms.rules.service.business;
 
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.AbstractGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityQueryFactGenerator;
-import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityRequestFactGenerator;
+import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityFaReportFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityResponseFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.SalesQueryFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.SalesReportFactGenerator;
@@ -35,7 +35,7 @@ public class BusinessObjectFactory {
             switch (businessObjectType) {
                 case RECEIVING_FA_REPORT_MSG:
                 case SENDING_FA_REPORT_MSG:
-                    return new ActivityRequestFactGenerator();
+                    return new ActivityFaReportFactGenerator();
                 case SENDING_FA_RESPONSE_MSG:
                 case RECEIVING_FA_RESPONSE_MSG:
                     return new ActivityResponseFactGenerator();

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/AbstractGenerator.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/AbstractGenerator.java
@@ -13,15 +13,16 @@
 
 package eu.europa.ec.fisheries.uvms.rules.service.business.generator;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import eu.europa.ec.fisheries.uvms.commons.date.XMLDateUtils;
 import eu.europa.ec.fisheries.uvms.rules.service.business.AbstractFact;
 import eu.europa.ec.fisheries.uvms.rules.service.config.ExtraValueType;
 import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesValidationException;
 import org.apache.commons.collections.CollectionUtils;
+import org.joda.time.DateTime;
+import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXReportDocument;
+import un.unece.uncefact.data.standard.unqualifieddatatype._20.DateTimeType;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
 
 /**
@@ -56,14 +57,23 @@ public abstract class AbstractGenerator<T> {
     /**
      * This method is setting unique UUIDs to a list of facts
      * eg. FaReportDocumentIDS, FluxReportMessageIDs, FAResponseMessageIDs
-     * @param ids
+     * @param fluxRepDoc
      * @param facts
      */
-    void setUniqueIDs(List<IDType> ids, List<AbstractFact> facts) {
-        List<String> strIDs = getIds(ids);
+    void populateUniqueIDsAndFaReportDocumentDate(FLUXReportDocument fluxRepDoc, List<AbstractFact> facts) {
+        List<String> strIDs = getIds(fluxRepDoc.getIDS());
+        DateTimeType creationDateTime = fluxRepDoc.getCreationDateTime();
+        DateTime reportDateTime = null;
+        if(creationDateTime != null){
+            Date repDat = XMLDateUtils.xmlGregorianCalendarToDate(creationDateTime.getDateTime());
+            if(repDat != null){
+                reportDateTime = new DateTime(repDat);
+            }
+        }
         facts.removeAll(Collections.singleton(null));
         for (AbstractFact fact : facts) {
             fact.setUniqueIds(strIDs);
+            fact.setCreationDateOfMessage(reportDateTime);
         }
     }
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/ActivityFaReportFactGenerator.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/ActivityFaReportFactGenerator.java
@@ -82,7 +82,7 @@ import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
  * @author Andi Kovi
  */
 @Slf4j
-public class ActivityRequestFactGenerator extends AbstractGenerator {
+public class ActivityFaReportFactGenerator extends AbstractGenerator {
 
     private FLUXFAReportMessage fluxfaReportMessage;
 
@@ -90,7 +90,7 @@ public class ActivityRequestFactGenerator extends AbstractGenerator {
 
     private ActivityFactMapper activityFactMapper;
 
-    public ActivityRequestFactGenerator() {
+    public ActivityFaReportFactGenerator() {
         xPathUtil = new XPathStringWrapper();
         activityFactMapper = new ActivityFactMapper(xPathUtil);
     }
@@ -144,7 +144,7 @@ public class ActivityRequestFactGenerator extends AbstractGenerator {
                 FLUXReportDocument relatedFLUXReportDocument = faReportDocument.getRelatedFLUXReportDocument();
 
                 if (relatedFLUXReportDocument != null){
-                    setUniqueIDs(relatedFLUXReportDocument.getIDS(), factsByReport);
+                    populateUniqueIDsAndFaReportDocumentDate(relatedFLUXReportDocument, factsByReport);
                 }
 
                 facts.addAll(factsByReport);

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/helper/ObjectRepresentationHelper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/helper/ObjectRepresentationHelper.java
@@ -40,7 +40,6 @@ public class ObjectRepresentationHelper {
                 foundObjectRepresentationsIterator.remove();
             }
         }
-
         return foundObjectRepresentations;
     }
 

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/TemplateEngineBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/TemplateEngineBeanTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import eu.europa.ec.fisheries.remote.RulesDomainModel;
 import eu.europa.ec.fisheries.uvms.rules.model.dto.TemplateRuleMapDto;
 import eu.europa.ec.fisheries.uvms.rules.service.business.AbstractFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityRequestFactGenerator;
+import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityFaReportFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesValidationException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -92,7 +92,7 @@ public class TemplateEngineBeanTest {
         }).when(ruleEvaluator).validateFacts(Mockito.anyList());
 
         List<AbstractFact> facts = new ArrayList<>();
-        ActivityRequestFactGenerator generator = new ActivityRequestFactGenerator();
+        ActivityFaReportFactGenerator generator = new ActivityFaReportFactGenerator();
         generator.setBusinessObjectMessage(getFluxFaReportMessage());
         facts.addAll(generator.generateAllFacts());
         templateEngine.evaluateFacts(facts);
@@ -105,7 +105,7 @@ public class TemplateEngineBeanTest {
 
     @Test
     public void testGenaratorThrows(){
-        ActivityRequestFactGenerator generator = new ActivityRequestFactGenerator();
+        ActivityFaReportFactGenerator generator = new ActivityFaReportFactGenerator();
         boolean threw = false;
         try {
             generator.setBusinessObjectMessage(new String());

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBeanTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import un.unece.uncefact.data.standard.mdr.communication.ColumnDataType;
 import un.unece.uncefact.data.standard.mdr.communication.ObjectRepresentation;
@@ -767,11 +768,11 @@ public class SalesRulesServiceBeanTest {
         typeCode.setValue("FLAG");
 
         //mock
-        doReturn(false).when(mdrService).isPresentInMDRList("TERRITORY", "INVALIDFLAG");
+        doReturn(false).when(mdrService).isPresentInMDRList(eq("TERRITORY"), eq("INVALIDFLAG"), Mockito.any(DateTime.class));
 
         //execute and verify
         assertTrue(service.isSalesQueryParameterValueNotValid(typeCode, valueCode));
-        verify(mdrService).isPresentInMDRList("TERRITORY", "INVALIDFLAG");
+        verify(mdrService).isPresentInMDRList(eq("TERRITORY"), eq("INVALIDFLAG"), Mockito.any(DateTime.class));
     }
 
     @Test
@@ -785,11 +786,11 @@ public class SalesRulesServiceBeanTest {
         typeCode.setValue("FLAG");
 
         //mock
-        doReturn(true).when(mdrService).isPresentInMDRList("TERRITORY", "BEL");
+        when(mdrService.isPresentInMDRList(eq("TERRITORY"), eq("BEL"), Mockito.any(DateTime.class))).thenReturn(true);
 
         //execute and verify
         assertFalse(service.isSalesQueryParameterValueNotValid(typeCode, valueCode));
-        verify(mdrService).isPresentInMDRList("TERRITORY", "BEL");
+        verify(mdrService).isPresentInMDRList(eq("TERRITORY"), eq("BEL"), Mockito.any(DateTime.class));
     }
 
     @Test
@@ -802,11 +803,11 @@ public class SalesRulesServiceBeanTest {
         typeCode.setValue("ROLE");
 
         //mock
-        doReturn(false).when(mdrService).isPresentInMDRList("FLUX_SALES_QUERY_PARAM_ROLE", "UNKNOWN");
+        doReturn(false).when(mdrService).isPresentInMDRList(eq("FLUX_SALES_QUERY_PARAM_ROLE"), eq("UNKNOWN"), Mockito.any(DateTime.class));
 
         //execute and verify
         assertTrue(service.isSalesQueryParameterValueNotValid(typeCode, valueCode));
-        verify(mdrService).isPresentInMDRList("FLUX_SALES_QUERY_PARAM_ROLE", "UNKNOWN");
+        verify(mdrService).isPresentInMDRList(eq("FLUX_SALES_QUERY_PARAM_ROLE"), eq("UNKNOWN"), Mockito.any(DateTime.class));
     }
 
     @Test
@@ -819,11 +820,11 @@ public class SalesRulesServiceBeanTest {
         typeCode.setValue("ROLE");
 
         //mock
-        doReturn(true).when(mdrService).isPresentInMDRList("FLUX_SALES_QUERY_PARAM_ROLE", "FLAG");
+        doReturn(true).when(mdrService).isPresentInMDRList(eq("FLUX_SALES_QUERY_PARAM_ROLE"), eq("FLAG"), Mockito.any(DateTime.class));
 
         //execute and verify
         assertFalse(service.isSalesQueryParameterValueNotValid(typeCode, valueCode));
-        verify(mdrService).isPresentInMDRList("FLUX_SALES_QUERY_PARAM_ROLE", "FLAG");
+        verify(mdrService).isPresentInMDRList(eq("FLUX_SALES_QUERY_PARAM_ROLE"), eq("FLAG"), Mockito.any(DateTime.class));
     }
 
     @Test
@@ -836,11 +837,11 @@ public class SalesRulesServiceBeanTest {
         typeCode.setValue("PLACE");
 
         //mock
-        doReturn(false).when(mdrService).isPresentInMDRList("LOCATION", "UNKNOWN");
+        doReturn(false).when(mdrService).isPresentInMDRList(eq("LOCATION"), eq("UNKNOWN"), Mockito.any(DateTime.class));
 
         //execute and verify
         assertTrue(service.isSalesQueryParameterValueNotValid(typeCode, valueCode));
-        verify(mdrService).isPresentInMDRList("LOCATION", "UNKNOWN");
+        verify(mdrService).isPresentInMDRList(eq("LOCATION"), eq("UNKNOWN") , Mockito.any(DateTime.class));
     }
 
     @Test
@@ -853,11 +854,11 @@ public class SalesRulesServiceBeanTest {
         typeCode.setValue("PLACE");
 
         //mock
-        doReturn(true).when(mdrService).isPresentInMDRList("LOCATION", "BEOST");
+        doReturn(true).when(mdrService).isPresentInMDRList(eq("LOCATION"), eq("BEOST"), Mockito.any(DateTime.class));
 
         //execute and verify
         assertFalse(service.isSalesQueryParameterValueNotValid(typeCode, valueCode));
-        verify(mdrService).isPresentInMDRList("LOCATION", "BEOST");
+        verify(mdrService).isPresentInMDRList(eq("LOCATION"), eq("BEOST"), Mockito.any(DateTime.class));
     }
 
     @Test

--- a/service/src/test/java/eu/europa/fisheries/uvms/rules/service/AbstractFactTest.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/rules/service/AbstractFactTest.java
@@ -45,7 +45,7 @@ import eu.europa.ec.fisheries.uvms.rules.service.business.fact.MeasureType;
 import eu.europa.ec.fisheries.uvms.rules.service.business.fact.NumericType;
 import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesPartyFact;
 import eu.europa.ec.fisheries.uvms.rules.service.business.fact.VesselTransportMeansFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityRequestFactGenerator;
+import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityFaReportFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.constants.FactConstants;
 import eu.europa.ec.fisheries.uvms.rules.service.constants.FishingActivityType;
 import eu.europa.ec.fisheries.uvms.rules.service.constants.MDRAcronymType;
@@ -1879,7 +1879,7 @@ public class AbstractFactTest {
     public void testIsEmptyCollectionsReflective(){
         FLUXFAReportMessage message = JAXBMarshaller.unMarshallMessage(
                 IOUtils.toString(new FileInputStream("src/test/resources/testData/faRepDocForEmptynessCheck.xml")), FLUXFAReportMessage.class);
-        ActivityRequestFactGenerator generator = new ActivityRequestFactGenerator();
+        ActivityFaReportFactGenerator generator = new ActivityFaReportFactGenerator();
         generator.setBusinessObjectMessage(message);
         for (AbstractFact abstractFact : generator.generateAllFacts()) {
             if(abstractFact instanceof FaReportDocumentFact){

--- a/service/src/test/java/eu/europa/fisheries/uvms/rules/service/business/ActivityFaReportFactGeneratorTest.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/rules/service/business/ActivityFaReportFactGeneratorTest.java
@@ -20,16 +20,16 @@ import java.util.List;
 import java.util.Map;
 
 import eu.europa.ec.fisheries.uvms.rules.service.business.fact.IdTypeWithFlagState;
-import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityRequestFactGenerator;
+import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityFaReportFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.config.ExtraValueType;
 import eu.europa.ec.fisheries.uvms.rules.service.mapper.fact.ActivityFactMapper;
 import eu.europa.ec.fisheries.uvms.rules.service.mapper.xpath.util.XPathStringWrapper;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ActivityRequestFactGeneratorTest {
+public class ActivityFaReportFactGeneratorTest {
 
-    private ActivityRequestFactGenerator generator;
+    private ActivityFaReportFactGenerator generator;
 
     private ActivityFactMapper mapper = new ActivityFactMapper(new XPathStringWrapper());
 
@@ -37,7 +37,7 @@ public class ActivityRequestFactGeneratorTest {
 
     @Before
     public void before(){
-        generator = new ActivityRequestFactGenerator();
+        generator = new ActivityFaReportFactGenerator();
         setInternalState(generator, "activityFactMapper", mapper);
         Map<ExtraValueType, Object> map = new HashMap<>();
         idTypeWithFlagState = new IdTypeWithFlagState();

--- a/service/src/test/java/eu/europa/fisheries/uvms/rules/service/business/BusinessObjectFactoryTest.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/rules/service/business/BusinessObjectFactoryTest.java
@@ -25,7 +25,7 @@ import eu.europa.ec.fisheries.uvms.rules.service.business.AbstractFact;
 import eu.europa.ec.fisheries.uvms.rules.service.business.BusinessObjectFactory;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.AbstractGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityQueryFactGenerator;
-import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityRequestFactGenerator;
+import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityFaReportFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.ActivityResponseFactGenerator;
 import eu.europa.ec.fisheries.uvms.rules.service.config.BusinessObjectType;
 import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesValidationException;
@@ -65,7 +65,7 @@ public class BusinessObjectFactoryTest {
     @Test
     @SneakyThrows
     public void testAllFishingActivityTypeFromGenerator(){
-        ActivityRequestFactGenerator generator = new ActivityRequestFactGenerator();
+        ActivityFaReportFactGenerator generator = new ActivityFaReportFactGenerator();
         generator.setBusinessObjectMessage(loadTestData(testXmlPath));
         List<AbstractFact> facts = generator.generateAllFacts();
 

--- a/service/src/test/java/eu/europa/fisheries/uvms/rules/service/mapper/fact/ActivityFactMapperTest.java
+++ b/service/src/test/java/eu/europa/fisheries/uvms/rules/service/mapper/fact/ActivityFactMapperTest.java
@@ -331,7 +331,7 @@ public class ActivityFactMapperTest {
         FishingActivityFact fishingActivityFact = fishingActivityFacts.get(0);
 
         assertEquals(fishingActivityFact.getTypeCode().getValue(), "LANDING");
-        assertEquals(fishingActivityFact.getOccurrenceDateTime().toString(), "Sun Apr 17 09:02:00 CEST 2016");
+        assertEquals(fishingActivityFact.getOccurrenceDateTime().toString(), "Sun Apr 17 07:02:00 UTC 2016");
 
     }
 
@@ -346,7 +346,7 @@ public class ActivityFactMapperTest {
         assertNotNull(fishingActivityFact);
 
         assertEquals(fishingActivityFact.getTypeCode().getValue(), "LANDING");
-        assertEquals(fishingActivityFact.getOccurrenceDateTime().toString(), "Sun Apr 17 09:02:00 CEST 2016");
+        assertEquals(fishingActivityFact.getOccurrenceDateTime().toString(), "Sun Apr 17 07:02:00 UTC 2016");
 
     }
 


### PR DESCRIPTION
1. Cleaned MdrCacheService and related bean definition from deprecated methods.
2. Change rule_init.xml in order to use the mdr related methods which check also the validity date.
3. MDR cache now will be loaded only when needed and not automatically each hour.
    Only when needed = MDR codelists were updated.

4. Stijn could you please confirm the change to the SalesRulesServiceBean.java bean?