### PR TITLE
Fix: rules won't deploy if messages are present on the queue before deployment

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/caches/MDRCache.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/caches/MDRCache.java
@@ -10,28 +10,6 @@ package eu.europa.ec.fisheries.uvms.rules.service.bean.caches;
  details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import static eu.europa.ec.fisheries.uvms.activity.model.mapper.JAXBMarshaller.unmarshallTextMessage;
-import static java.util.Collections.emptyList;
-import static java.util.concurrent.TimeUnit.MINUTES;
-
-import javax.annotation.PostConstruct;
-import javax.ejb.AccessTimeout;
-import javax.ejb.EJB;
-import javax.ejb.Lock;
-import javax.ejb.LockType;
-import javax.ejb.Singleton;
-import javax.ejb.Startup;
-import javax.jms.JMSException;
-import javax.jms.TextMessage;
-import javax.xml.bind.JAXBException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.base.Stopwatch;
 import eu.europa.ec.fisheries.uvms.commons.date.DateUtils;
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageException;
@@ -52,6 +30,19 @@ import un.unece.uncefact.data.standard.mdr.communication.ColumnDataType;
 import un.unece.uncefact.data.standard.mdr.communication.MdrGetCodeListResponse;
 import un.unece.uncefact.data.standard.mdr.communication.MdrGetLastRefreshDateResponse;
 import un.unece.uncefact.data.standard.mdr.communication.ObjectRepresentation;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.*;
+import javax.jms.JMSException;
+import javax.jms.TextMessage;
+import javax.xml.bind.JAXBException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static eu.europa.ec.fisheries.uvms.activity.model.mapper.JAXBMarshaller.unmarshallTextMessage;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * @author Gregory Rinaldi, Andi Kovi
@@ -237,6 +228,7 @@ public class MDRCache {
         }
     }
 
+    @AccessTimeout(value = 10, unit = MINUTES)
     public EnrichedBRMessage getErrorMessage(String brId) {
         return errorMessages.get(brId);
     }


### PR DESCRIPTION
Rules won't deploy if messages are present on the Rules queue.

The problem is the following:

- a message is processed during deployment
- to do the processing, multiple methods of the MDRCache need to be used. The bean needs to do some intialisiation on the first call, which takes more than 5 seconds
- Since the MDRCache is a singleton, and the bean is not responding for more than 5 seconds, the invocation of the bean fails. We get a ConcurrentAccessTimeoutException.

In order to have a workaround for this problem, I've increased the method invocation timeout.
