### PR TITLE
Avoid that Rules hangs for 10 minutes, and some cleanup

### DIFF
--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/consumer/bean/RulesEventMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/consumer/bean/RulesEventMessageConsumerBean.java
@@ -12,39 +12,11 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
 
 package eu.europa.ec.fisheries.uvms.rules.message.consumer.bean;
 
-import javax.ejb.ActivationConfigProperty;
-import javax.ejb.MessageDriven;
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
-import javax.jms.Message;
-import javax.jms.MessageListener;
-import javax.jms.TextMessage;
-import java.util.UUID;
-
 import eu.europa.ec.fisheries.schema.rules.module.v1.RulesBaseRequest;
 import eu.europa.ec.fisheries.schema.rules.module.v1.RulesModuleMethod;
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
 import eu.europa.ec.fisheries.uvms.commons.message.context.MappedDiagnosticContext;
-import eu.europa.ec.fisheries.uvms.rules.message.event.CountTicketsByMovementsEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.ErrorEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.GetCustomRuleReceivedEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.GetFLUXMDRSyncMessageResponseEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.GetTicketsAndRulesByMovementsEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.GetTicketsByMovementsEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.PingReceivedEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.RcvFluxResponseEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.ReceiveSalesQueryEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.ReceiveSalesReportEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.ReceiveSalesResponseEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SendFaQueryEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SendFaReportEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SendSalesReportEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SendSalesResponseEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SetFLUXFAReportMessageReceivedEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SetFLUXMDRSyncMessageReceivedEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SetFluxFaQueryMessageReceivedEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.SetMovementReportReceivedEvent;
-import eu.europa.ec.fisheries.uvms.rules.message.event.ValidateMovementReportReceivedEvent;
+import eu.europa.ec.fisheries.uvms.rules.message.event.*;
 import eu.europa.ec.fisheries.uvms.rules.message.event.carrier.EventMessage;
 import eu.europa.ec.fisheries.uvms.rules.model.constant.FaultCode;
 import eu.europa.ec.fisheries.uvms.rules.model.exception.RulesModelMarshallException;
@@ -53,6 +25,15 @@ import eu.europa.ec.fisheries.uvms.rules.model.mapper.ModuleResponseMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+import java.util.UUID;
 
 /**
  * Message driven bean that receives all messages that
@@ -207,26 +188,6 @@ public class RulesEventMessageConsumerBean implements MessageListener {
                 case RECEIVE_SALES_QUERY:
                     receiveSalesQueryEvent.fire(new EventMessage(textMessage));
                     break;
-
-                /** @deprecated
-                 * This code has moved to RulesDefaultSelectorEventConsumer.
-                 *  If you use the latest version of Exchange and Sales, this code will not be called anymore.
-                 *  For the parties that still use an older version of Exchange and Sales, this code is kept.
-                 *  Please upgrade as soon as possible. We'll remove this code in a next release.
-                 */
-                case RECEIVE_SALES_RESPONSE:
-                    receiveSalesResponseEvent.fire(new EventMessage(textMessage));
-                    break;
-                case RECEIVE_SALES_REPORT:
-                    receiveSalesReportEvent.fire(new EventMessage(textMessage));
-                    break;
-                case SEND_SALES_REPORT:
-                    sendSalesReportEvent.fire(new EventMessage(textMessage));
-                    break;
-                case SEND_SALES_RESPONSE:
-                    sendSalesResponseEvent.fire(new EventMessage(textMessage));
-                    break;
-                /** end deprecation **/
                 default:
                     LOG.error("[ Request method '{}' is not implemented ]", method.name());
                     errorEvent.fire(new EventMessage(textMessage, ModuleResponseMapper.createFaultMessage(FaultCode.RULES_MESSAGE, "Method not implemented:" + method.name())));

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/consumer/bean/RulesExchangeGetValidationConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/consumer/bean/RulesExchangeGetValidationConsumerBean.java
@@ -11,15 +11,6 @@ copy of the GNU General Public License along with the IFDM Suite. If not, see <h
  */
 package eu.europa.ec.fisheries.uvms.rules.message.consumer.bean;
 
-import javax.ejb.ActivationConfigProperty;
-import javax.ejb.MessageDriven;
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
-import javax.jms.Message;
-import javax.jms.MessageListener;
-import javax.jms.TextMessage;
-import java.util.UUID;
-
 import eu.europa.ec.fisheries.schema.rules.module.v1.RulesBaseRequest;
 import eu.europa.ec.fisheries.schema.rules.module.v1.RulesModuleMethod;
 import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
@@ -35,6 +26,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+import java.util.UUID;
+
 /**
  * Message driven bean that receives all messages that
  * have no message selector.
@@ -49,7 +49,7 @@ import org.slf4j.MDC;
         @ActivationConfigProperty(propertyName = "maximumRedeliveries", propertyValue = "3"),
         @ActivationConfigProperty(propertyName = "maxSessions", propertyValue = "10")
 })
-public class RulesExchangeGetValidationConumerBean implements MessageListener {
+public class RulesExchangeGetValidationConsumerBean implements MessageListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(RulesEventMessageConsumerBean.class);
 
@@ -86,14 +86,6 @@ public class RulesExchangeGetValidationConumerBean implements MessageListener {
             errorEvent.fire(new EventMessage(textMessage, ModuleResponseMapper.createFaultMessage(FaultCode.RULES_MESSAGE, "Error when receiving message in rules:" + e.getMessage())));
         } finally {
             MDC.remove("clientName");
-        }
-    }
-
-    private int getTimesRedelivered(Message message) {
-        try {
-            return (message.getIntProperty("JMSXDeliveryCount") - 1);
-        } catch (Exception e) {
-            return 0;
         }
     }
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/ActivityServiceBeanHelper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/ActivityServiceBeanHelper.java
@@ -1,16 +1,6 @@
 package eu.europa.ec.fisheries.uvms.rules.service.bean.sales.helper;
 
 
-import static org.apache.commons.collections.CollectionUtils.isEmpty;
-
-import javax.ejb.EJB;
-import javax.ejb.Singleton;
-import javax.jms.JMSException;
-import javax.jms.TextMessage;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import com.google.common.base.Optional;
 import eu.europa.ec.fisheries.uvms.activity.model.exception.ActivityModelMarshallException;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingTripResponse;
@@ -29,6 +19,16 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
 
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.jms.JMSException;
+import javax.jms.TextMessage;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
+
 @Slf4j
 @Singleton
 public class ActivityServiceBeanHelper {
@@ -43,7 +43,7 @@ public class ActivityServiceBeanHelper {
     private ActivityModuleRequestMapperFacade activityMapper;
 
     protected Optional<FishingTripResponse> receiveMessageFromActivity(String correlationId) throws MessageException, JMSException, SalesMarshallException {
-        TextMessage receivedMessageAsTextMessage = messageConsumer.getMessage(correlationId, TextMessage.class);
+        TextMessage receivedMessageAsTextMessage = messageConsumer.getMessage(correlationId, TextMessage.class, 30000L);
         log.debug("Received response message");
         String receivedMessageAsString = receivedMessageAsTextMessage.getText();
         return unmarshal(receivedMessageAsString);

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/AssetServiceBeanHelper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/AssetServiceBeanHelper.java
@@ -13,7 +13,7 @@ public class AssetServiceBeanHelper {
 //    private RulesResponseConsumer messageConsumer;
 //
 //    protected List<Asset> receiveMessageFromAsset(String correlationId) throws MessageException, AssetModelMarshallException {
-//        TextMessage receivedMessage = messageConsumer.getMessage(correlationId, TextMessage.class);
+//        TextMessage receivedMessage = messageConsumer.getMessage(correlationId, TextMessage.class, 30000L);
 //        return unmarshal(receivedMessage);
 //    }
 //

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/SalesServiceBeanHelper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/SalesServiceBeanHelper.java
@@ -71,7 +71,7 @@ public class SalesServiceBeanHelper {
         log.info("Send CheckForUniqueIdRequest message to Sales");
         String correlationID = sendMessageToSales(checkForUniqueIdRequest);
 
-        TextMessage receivedMessageAsTextMessage = messageConsumer.getMessage(correlationID, TextMessage.class, 60000L);
+        TextMessage receivedMessageAsTextMessage = messageConsumer.getMessage(correlationID, TextMessage.class, 30000L);
         log.info("Received response message");
         CheckForUniqueIdResponse response = JAXBMarshaller.unmarshallString(receivedMessageAsTextMessage.getText(), CheckForUniqueIdResponse.class);
         return !response.isUnique();

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/ActivityServiceBeanHelperTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/helper/ActivityServiceBeanHelperTest.java
@@ -61,12 +61,12 @@ public class ActivityServiceBeanHelperTest {
 
         TextMessage mockTextMessage = mock(TextMessage.class);
         doReturn(message).when(mockTextMessage).getText();
-        doReturn(mockTextMessage).when(messageConsumer).getMessage(correlationId, TextMessage.class);
+        doReturn(mockTextMessage).when(messageConsumer).getMessage(correlationId, TextMessage.class, 30000L);
 
         Optional<FishingTripResponse> fishingTripResponseOptional = helper.receiveMessageFromActivity(correlationId);
 
         verify(mockTextMessage).getText();
-        verify(messageConsumer).getMessage(correlationId, TextMessage.class);
+        verify(messageConsumer).getMessage(correlationId, TextMessage.class, 30000L);
         verifyNoMoreInteractions(messageConsumer, messageProducer);
 
         verifyStatic();
@@ -119,7 +119,7 @@ public class ActivityServiceBeanHelperTest {
 
         TextMessage mockTextMessage = mock(TextMessage.class);
         doReturn(message).when(mockTextMessage).getText();
-        doReturn(mockTextMessage).when(messageConsumer).getMessage(correlationId, TextMessage.class);
+        doReturn(mockTextMessage).when(messageConsumer).getMessage(correlationId, TextMessage.class, 30000L);
         doReturn(correlationId).when(messageProducer).sendDataSourceMessage("FishingTripResponse", DataSourceQueue.ACTIVITY);
         doReturn("FishingTripResponse").when(activityMapper).mapToActivityGetFishingTripRequest(listFilter, singleFilters);
 
@@ -129,7 +129,7 @@ public class ActivityServiceBeanHelperTest {
         Optional<FishingTripResponse> fishingTripResponseOptional = helper.findTrip(fishingTripID);
 
         verify(mockTextMessage).getText();
-        verify(messageConsumer).getMessage(correlationId, TextMessage.class);
+        verify(messageConsumer).getMessage(correlationId, TextMessage.class, 30000L);
         verify(messageProducer).sendDataSourceMessage("FishingTripResponse", DataSourceQueue.ACTIVITY);
 
         verifyNoMoreInteractions(messageConsumer, messageProducer);


### PR DESCRIPTION
When contacting another module, and blocking the thread waiting for a response, it is possible that the thread gets blocked for 10 minutes.

We've introduced a limit of 30 seconds, to avoid this situation.

Also, removed some deprecated code for Sales.