### PR TITLE
Improvement/creation date time to parse also date time string

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/ActivityFaReportFactGenerator.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/ActivityFaReportFactGenerator.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
 import un.unece.uncefact.data.standard.fluxfareportmessage._3.FLUXFAReportMessage;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.*;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
@@ -404,9 +405,10 @@ public class ActivityFaReportFactGenerator extends AbstractGenerator {
         if (fluxRepDoc != null){
             List<String> strIDs = getIds(fluxRepDoc.getIDS());
             facts.removeAll(Collections.singleton(null));
+            DateTime creationDateTime = activityFactMapper.mapToJodaDateTime(fluxRepDoc.getCreationDateTime());
             for (AbstractFact fact : facts) {
                 fact.setUniqueIds(strIDs);
-                fact.setCreationDateOfMessage(activityFactMapper.extractCreationDateTime(fluxRepDoc));
+                fact.setCreationDateOfMessage(creationDateTime);
             }
         }
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/ActivityQueryFactGenerator.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/generator/ActivityQueryFactGenerator.java
@@ -13,7 +13,6 @@
 
 package eu.europa.ec.fisheries.uvms.rules.service.business.generator;
 
-import eu.europa.ec.fisheries.uvms.commons.date.XMLDateUtils;
 import eu.europa.ec.fisheries.uvms.rules.service.business.AbstractFact;
 import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesValidationException;
 import eu.europa.ec.fisheries.uvms.rules.service.mapper.fact.ActivityFactMapper;
@@ -21,10 +20,8 @@ import eu.europa.ec.fisheries.uvms.rules.service.mapper.xpath.util.XPathStringWr
 import org.joda.time.DateTime;
 import un.unece.uncefact.data.standard.fluxfaquerymessage._3.FLUXFAQueryMessage;
 import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FAQuery;
-import un.unece.uncefact.data.standard.unqualifieddatatype._20.DateTimeType;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import static eu.europa.ec.fisheries.uvms.rules.service.config.ExtraValueType.SENDER_RECEIVER;
@@ -55,9 +52,9 @@ public class ActivityQueryFactGenerator extends AbstractGenerator {
     @Override
     public List<AbstractFact> generateAllFacts() {
         List<AbstractFact> factList = new ArrayList<>();
-        if (fluxfaQueryMessage != null){
+        if (fluxfaQueryMessage != null) {
             FAQuery faQuery = fluxfaQueryMessage.getFAQuery();
-            if(faQuery != null){
+            if (faQuery != null) {
 
                 xPathUtil.append(FLUXFA_QUERY_MESSAGE).append(FA_QUERY);
                 factList.add(activityFactMapper.generateFactsForFaQuery(faQuery));
@@ -66,20 +63,19 @@ public class ActivityQueryFactGenerator extends AbstractGenerator {
                 factList.addAll(activityFactMapper.generateFactsForFaQueryParameters(faQuery.getSimpleFAQueryParameters(), faQuery));
             }
         }
+        populateCreationDateTime(factList);
+        return factList;
+    }
 
-        if (fluxfaQueryMessage != null){
-            DateTimeType creationDateTime = fluxfaQueryMessage.getFAQuery().getSubmittedDateTime();
-            for (AbstractFact fact : factList) {
-                if(creationDateTime != null){
-                    Date repDat = XMLDateUtils.xmlGregorianCalendarToDate(creationDateTime.getDateTime());
-                    if(repDat != null){
-                        fact.setCreationDateOfMessage(new DateTime(repDat));
-                    }
+    private void populateCreationDateTime(List<AbstractFact> factList) {
+        if (fluxfaQueryMessage != null && fluxfaQueryMessage.getFAQuery() != null) {
+            DateTime dateTimeOfCreationOfMessage = activityFactMapper.mapToJodaDateTime(fluxfaQueryMessage.getFAQuery().getSubmittedDateTime());
+            if (dateTimeOfCreationOfMessage != null) {
+                for (AbstractFact fact : factList) {
+                    fact.setCreationDateOfMessage(dateTimeOfCreationOfMessage);
                 }
             }
         }
-
-        return factList;
     }
 
     @Override

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/mapper/fact/ActivityFactMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/mapper/fact/ActivityFactMapper.java
@@ -31,6 +31,8 @@ import un.unece.uncefact.data.standard.unqualifieddatatype._20.QuantityType;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.TextType;
 
 import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static eu.europa.ec.fisheries.uvms.rules.service.constants.XPathConstants.*;
@@ -234,7 +236,9 @@ public class ActivityFactMapper {
         for (FAReportDocument fAReportDocument : faReportDocuments) {
             xPathUtil.append(FLUXFA_REPORT_MESSAGE).appendWithIndex(FA_REPORT_DOCUMENT, index);
             FaReportDocumentFact faReportDocumentFact = generateFactForFaReportDocument(fAReportDocument);
-            faReportDocumentFact.setCreationDateOfMessage(extractCreationDateTime(fAReportDocument.getRelatedFLUXReportDocument()));
+            if(fAReportDocument.getRelatedFLUXReportDocument() != null){
+                faReportDocumentFact.setCreationDateOfMessage(mapToJodaDateTime(fAReportDocument.getRelatedFLUXReportDocument().getCreationDateTime()));
+            }
             faReportDocumentFact.setTripsPerFaTypeFromMessage(tripsPerFaTypeFromMessage);
             list.add(faReportDocumentFact);
             index++;
@@ -344,17 +348,24 @@ public class ActivityFactMapper {
         return fishingActivityFact;
     }
 
-    public DateTime extractCreationDateTime(FLUXReportDocument fluxReportDoc){
-        if (fluxReportDoc != null){
-            DateTimeType creationDateTime = fluxReportDoc.getCreationDateTime();
-            if(creationDateTime != null){
-                Date repDat = XMLDateUtils.xmlGregorianCalendarToDate(creationDateTime.getDateTime());
-                return new DateTime(repDat);
+    public DateTime mapToJodaDateTime(DateTimeType creationDateTime) {
+        DateTime dateTimeOfCreationOfMessage = null;
+        if (creationDateTime != null) {
+            Date repDat = XMLDateUtils.xmlGregorianCalendarToDate(creationDateTime.getDateTime());
+            if (repDat != null) {
+                dateTimeOfCreationOfMessage = new DateTime(repDat);
+            } else if (creationDateTime.getDateTimeString() != null && org.apache.commons.lang3.StringUtils.isNotEmpty(creationDateTime.getDateTimeString().getValue())) {
+                SimpleDateFormat df = new SimpleDateFormat();
+                try {
+                    Date parsedDate = df.parse(creationDateTime.getDateTimeString().getValue());
+                    dateTimeOfCreationOfMessage = new DateTime(parsedDate);
+                } catch (ParseException e) {
+                    log.warn("[WARN] Couldn't extract date from CreationDateTime of Message!", e);
+                }
             }
         }
-        return null;
+        return dateTimeOfCreationOfMessage;
     }
-
 
     public FluxFaReportMessageFact generateFactForFluxFaReportMessage(FLUXFAReportMessage fluxfaReportMessage) {
         if (fluxfaReportMessage == null) {
@@ -365,7 +376,9 @@ public class ActivityFactMapper {
 
         fluxFaReportMessageFact.setSenderOrReceiver(senderReceiver);
 
-        fluxFaReportMessageFact.setCreationDateOfMessage(extractCreationDateTime(fluxfaReportMessage.getFLUXReportDocument()));
+        if(fluxfaReportMessage.getFLUXReportDocument() != null){
+            fluxFaReportMessageFact.setCreationDateOfMessage(mapToJodaDateTime(fluxfaReportMessage.getFLUXReportDocument().getCreationDateTime()));
+        }
 
         String partialXpath = xPathUtil.append(FLUXFA_REPORT_MESSAGE).getValue();
 

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/mapper/fact/ActivityFactMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/mapper/fact/ActivityFactMapper.java
@@ -11,6 +11,7 @@ details. You should have received a copy of the GNU General Public License along
 
 package eu.europa.ec.fisheries.uvms.rules.service.mapper.fact;
 
+import eu.europa.ec.fisheries.uvms.commons.date.DateUtils;
 import eu.europa.ec.fisheries.uvms.commons.date.XMLDateUtils;
 import eu.europa.ec.fisheries.uvms.rules.dto.GearMatrix;
 import eu.europa.ec.fisheries.uvms.rules.service.business.AbstractFact;
@@ -31,8 +32,6 @@ import un.unece.uncefact.data.standard.unqualifieddatatype._20.QuantityType;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.TextType;
 
 import java.math.BigDecimal;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static eu.europa.ec.fisheries.uvms.rules.service.constants.XPathConstants.*;
@@ -355,11 +354,10 @@ public class ActivityFactMapper {
             if (repDat != null) {
                 dateTimeOfCreationOfMessage = new DateTime(repDat);
             } else if (creationDateTime.getDateTimeString() != null && org.apache.commons.lang3.StringUtils.isNotEmpty(creationDateTime.getDateTimeString().getValue())) {
-                SimpleDateFormat df = new SimpleDateFormat();
                 try {
-                    Date parsedDate = df.parse(creationDateTime.getDateTimeString().getValue());
+                    Date parsedDate = DateUtils.parseToUTCDate(creationDateTime.getDateTimeString().getValue(),creationDateTime.getDateTimeString().getFormat());
                     dateTimeOfCreationOfMessage = new DateTime(parsedDate);
-                } catch (ParseException e) {
+                } catch (IllegalArgumentException e) {
                     log.warn("[WARN] Couldn't extract date from CreationDateTime of Message!", e);
                 }
             }

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/business/ActivityFactMapperTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/business/ActivityFactMapperTest.java
@@ -10,102 +10,39 @@
 
 package eu.europa.ec.fisheries.uvms.rules.service.business;
 
-import static eu.europa.ec.fisheries.uvms.rules.service.constants.XPathConstants.SPECIFIED_FISHING_GEAR;
-import static eu.europa.ec.fisheries.uvms.rules.service.constants.XPathConstants.SPECIFIED_FLUX_CHARACTERISTIC;
-import static java.util.Collections.singletonList;
-import static org.apache.commons.collections.CollectionUtils.isEmpty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import javax.xml.datatype.DatatypeFactory;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.List;
-
 import eu.europa.ec.fisheries.uvms.commons.message.impl.JAXBUtils;
 import eu.europa.ec.fisheries.uvms.mdr.model.exception.MdrModelMarshallException;
 import eu.europa.ec.fisheries.uvms.rules.dto.GearMatrix;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaArrivalFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaCatchFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaDepartureFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaDiscardFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaEntryToSeaFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaExitFromSeaFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaFishingOperationFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaJointFishingOperationFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaLandingFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaNotificationOfArrivalFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaNotificationOfTranshipmentFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaQueryFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaQueryParameterFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaRelocationFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaReportDocumentFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaResponseFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FaTranshipmentFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FishingGearFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FishingTripFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FluxCharacteristicsFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FluxFaReportMessageFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.FluxLocationFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.GearCharacteristicsFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.GearProblemFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.IdType;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.StructuredAddressFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.ValidationQualityAnalysisFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.VesselStorageCharacteristicsFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.VesselTransportMeansFact;
+import eu.europa.ec.fisheries.uvms.rules.service.business.fact.*;
 import eu.europa.ec.fisheries.uvms.rules.service.business.generator.helper.ActivityObjectsHelper;
 import eu.europa.ec.fisheries.uvms.rules.service.mapper.FaResponseFactMapper;
 import eu.europa.ec.fisheries.uvms.rules.service.mapper.fact.ActivityFactMapper;
 import eu.europa.ec.fisheries.uvms.rules.service.mapper.xpath.util.XPathStringWrapper;
 import lombok.SneakyThrows;
 import org.apache.commons.io.IOUtils;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import un.unece.uncefact.data.standard.fluxfareportmessage._3.FLUXFAReportMessage;
 import un.unece.uncefact.data.standard.fluxresponsemessage._6.FLUXResponseMessage;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.AAPProcess;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.AAPProduct;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.ContactParty;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.DelimitedPeriod;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FACatch;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FAQuery;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FAQueryParameter;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FAReportDocument;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLAPDocument;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXCharacteristic;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXGeographicalCoordinate;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXLocation;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXReportDocument;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FLUXResponseDocument;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FishingActivity;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FishingGear;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.FishingTrip;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.GearCharacteristic;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.GearProblem;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.SizeDistribution;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.ValidationQualityAnalysis;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.ValidationResultDocument;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.VesselCountry;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.VesselStorageCharacteristic;
-import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.VesselTransportMeans;
+import un.unece.uncefact.data.standard.reusableaggregatebusinessinformationentity._20.*;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.CodeType;
-import un.unece.uncefact.data.standard.unqualifieddatatype._20.DateTimeType;
-import un.unece.uncefact.data.standard.unqualifieddatatype._20.IDType;
+import un.unece.uncefact.data.standard.unqualifieddatatype._20.*;
 import un.unece.uncefact.data.standard.unqualifieddatatype._20.MeasureType;
-import un.unece.uncefact.data.standard.unqualifieddatatype._20.QuantityType;
-import un.unece.uncefact.data.standard.unqualifieddatatype._20.TextType;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static eu.europa.ec.fisheries.uvms.rules.service.constants.XPathConstants.SPECIFIED_FISHING_GEAR;
+import static eu.europa.ec.fisheries.uvms.rules.service.constants.XPathConstants.SPECIFIED_FLUX_CHARACTERISTIC;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.junit.Assert.*;
 
 /**
  * @author Gregory Rinaldi
@@ -931,6 +868,54 @@ public class ActivityFactMapperTest {
         idType.setSchemeID(null);
         document.setIDS(singletonList(idType));
         assertTrue(isEmpty(ActivityFactMapper.getIds(document)));
+    }
+
+    @Test
+    public void testMapToJodaDateTime() throws DatatypeConfigurationException {
+        ActivityFactMapper mapper = new ActivityFactMapper();
+        GregorianCalendar calendar = new GregorianCalendar();
+        calendar.setTime(new Date());
+        DateTimeType posDateTime = new DateTimeType();
+        posDateTime.setDateTime(DatatypeFactory.newInstance().newXMLGregorianCalendar(calendar));
+        DateTime dateTime = mapper.mapToJodaDateTime(posDateTime);
+        assertNotNull(dateTime);
+    }
+
+    @Test
+    public void testMapToJodaDateTimeNULL() {
+        ActivityFactMapper mapper = new ActivityFactMapper();
+        DateTime dateTime = mapper.mapToJodaDateTime(null);
+        assertNull(dateTime);
+    }
+
+    @Test
+    public void testMapToJodaDateTimeWithDateTimeString() {
+        ActivityFactMapper mapper = new ActivityFactMapper();
+        DateTimeType posDateTime = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString("2017-11-11T14:28:53.254Z","yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        posDateTime.setDateTimeString(dateTimeString);
+        DateTime dateTime = mapper.mapToJodaDateTime(posDateTime);
+        assertNotNull(dateTime);
+    }
+
+    @Test
+    public void testMapToJodaDateTimeWithDateTimeStringWronmgFormat() {
+        ActivityFactMapper mapper = new ActivityFactMapper();
+        DateTimeType posDateTime = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString("2017-11-11T14:28:53.254Z","WrongFormat");
+        posDateTime.setDateTimeString(dateTimeString);
+        DateTime dateTime = mapper.mapToJodaDateTime(posDateTime);
+        assertNull(dateTime);
+    }
+
+    @Test
+    public void testMapToJodaDateTimeWithDateTimeStringWronmgDate() {
+        ActivityFactMapper mapper = new ActivityFactMapper();
+        DateTimeType posDateTime = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString("Bl;ajahduh","yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        posDateTime.setDateTimeString(dateTimeString);
+        DateTime dateTime = mapper.mapToJodaDateTime(posDateTime);
+        assertNull(dateTime);
     }
 
 }


### PR DESCRIPTION
Improved the way the creationDateTime of message is retrieved and set to the facts.
Now it also supports DateTimeString type.
Tests related to new Mapper method.