### PR TITLE
Add new Belgium-specific rule and workaround for race condition

### DIFF
--- a/LIQUIBASE/schema/initdata/sales_rules.xml
+++ b/LIQUIBASE/schema/initdata/sales_rules.xml
@@ -2858,6 +2858,19 @@
             <column name="template_id" value="1004"/>
             <column name="property_names" value="specifiedFishingActivities"/>
         </insert>
+        <insert tableName="rule">
+            <column name="rule_id" value="11710"/>
+            <column name="br_id" value="SALE-BEL-08"/>
+            <column name="expression"
+                    value="isAuction() &amp;&amp; isVariousSupply() &amp;&amp; isEmpty(supplier)"/>
+            <column name="note" value=""/>
+            <column name="message" value="BEL:SALESupplier is mandatory"/>
+            <column name="level" value="L00"/>
+            <column name="error_type" value="ERROR"/>
+            <column name="template_id" value="1027"/>
+            <column name="property_names" value="supplier"/>
+            <column name="disabled" value="true"/>
+        </insert>
     </changeSet>
 
     <changeSet id="new-rules-ig-2-5-0" author="matbul">

--- a/LIQUIBASE/schema/initdata/sales_rules.xml
+++ b/LIQUIBASE/schema/initdata/sales_rules.xml
@@ -2869,7 +2869,7 @@
             <column name="error_type" value="ERROR"/>
             <column name="template_id" value="1027"/>
             <column name="property_names" value="supplier"/>
-            <column name="disabled" value="true"/>
+            <column name="disabled" value="false"/>
         </insert>
     </changeSet>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <asset.model.version>4.0.17</asset.model.version>
         <audit.model.version>4.0.4</audit.model.version>
         <rules.model.version>${project.version}</rules.model.version>
-        <sales.model.version>1.0.11-SNAPSHOT</sales.model.version>
+        <sales.model.version>1.0.11</sales.model.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javax.json.version>1.0.4</javax.json.version>
         <maven-release-plugin>2.5.3</maven-release-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <asset.model.version>4.0.17</asset.model.version>
         <audit.model.version>4.0.4</audit.model.version>
         <rules.model.version>${project.version}</rules.model.version>
-        <sales.model.version>1.0.10</sales.model.version>
+        <sales.model.version>1.0.11-SNAPSHOT</sales.model.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javax.json.version>1.0.4</javax.json.version>
         <maven-release-plugin>2.5.3</maven-release-plugin>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBean.java
@@ -1,44 +1,28 @@
 package eu.europa.ec.fisheries.uvms.rules.service.bean.sales;
 
 
-import static org.apache.commons.collections.CollectionUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import eu.europa.ec.fisheries.schema.sales.*;
+import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingActivitySummary;
+import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingTripResponse;
+import eu.europa.ec.fisheries.uvms.rules.service.*;
+import eu.europa.ec.fisheries.uvms.rules.service.business.FactWithReferencedId;
+import eu.europa.ec.fisheries.uvms.rules.service.business.fact.CodeType;
+import eu.europa.ec.fisheries.uvms.rules.service.business.fact.*;
+import eu.europa.ec.fisheries.uvms.rules.service.business.helper.ObjectRepresentationHelper;
+import eu.europa.ec.fisheries.uvms.rules.service.constants.MDRAcronymType;
+import ma.glasnost.orika.MapperFacade;
+import org.joda.time.DateTime;
+import un.unece.uncefact.data.standard.mdr.communication.ObjectRepresentation;
 
 import javax.ejb.EJB;
 import javax.ejb.Singleton;
 import javax.inject.Inject;
 import java.util.List;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import eu.europa.ec.fisheries.schema.sales.FLUXSalesReportMessage;
-import eu.europa.ec.fisheries.schema.sales.IDType;
-import eu.europa.ec.fisheries.schema.sales.SalesDocumentType;
-import eu.europa.ec.fisheries.schema.sales.SalesEventType;
-import eu.europa.ec.fisheries.schema.sales.SalesMessageIdType;
-import eu.europa.ec.fisheries.schema.sales.ValidationResultDocumentType;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingActivitySummary;
-import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingTripResponse;
-import eu.europa.ec.fisheries.uvms.rules.service.ActivityService;
-import eu.europa.ec.fisheries.uvms.rules.service.AssetService;
-import eu.europa.ec.fisheries.uvms.rules.service.MDRCacheRuleService;
-import eu.europa.ec.fisheries.uvms.rules.service.SalesRulesService;
-import eu.europa.ec.fisheries.uvms.rules.service.SalesService;
-import eu.europa.ec.fisheries.uvms.rules.service.business.FactWithReferencedId;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.CodeType;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.IdType;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesDelimitedPeriodFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesDocumentFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesFLUXReportDocumentFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesFLUXResponseDocumentFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesFLUXSalesReportMessageFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesFishingActivityFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.fact.SalesQueryFact;
-import eu.europa.ec.fisheries.uvms.rules.service.business.helper.ObjectRepresentationHelper;
-import eu.europa.ec.fisheries.uvms.rules.service.constants.MDRAcronymType;
-import ma.glasnost.orika.MapperFacade;
-import org.joda.time.DateTime;
-import un.unece.uncefact.data.standard.mdr.communication.ObjectRepresentation;
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Singleton
 public class SalesRulesServiceBean implements SalesRulesService {
@@ -121,14 +105,8 @@ public class SalesRulesServiceBean implements SalesRulesService {
             String fishingTripID = fact.getSalesReports().get(0).getIncludedSalesDocuments().get(0).getSpecifiedFishingActivities().get(0).getSpecifiedFishingTrip().getIDS().get(0).getValue();
 
             Optional<FishingTripResponse> fishingTripResponse = activityService.getFishingTrip(fishingTripID);
-
             if (!fishingTripResponse.isPresent()) {
-                /**
-                 * In case the query returns no values
-                 * (which means there was no fishing trip found with the ID specified in the sales note),
-                 * we don't fire the rule
-                 */
-                return false;
+                return true;
             }
 
             FishingTripResponse fishingTrip = fishingTripResponse.get();

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/fact/SalesAuctionSaleFact.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/business/fact/SalesAuctionSaleFact.java
@@ -10,6 +10,7 @@ public class SalesAuctionSaleFact extends SalesAbstractFact {
 
     protected String countryCode;
     protected SalesCategoryType salesCategory;
+    protected String supplier;
 
     @Override
     public void setFactType() {
@@ -32,6 +33,14 @@ public class SalesAuctionSaleFact extends SalesAbstractFact {
         this.salesCategory = salesCategory;
     }
 
+    public String getSupplier() {
+        return supplier;
+    }
+
+    public void setSupplier(String supplier) {
+        this.supplier = supplier;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -39,11 +48,12 @@ public class SalesAuctionSaleFact extends SalesAbstractFact {
         SalesAuctionSaleFact that = (SalesAuctionSaleFact) o;
         return Objects.equals(countryCode, that.countryCode) &&
                 salesCategory == that.salesCategory &&
-                Objects.equals(creationDateOfMessage, that.creationDateOfMessage);
+                Objects.equals(creationDateOfMessage, that.creationDateOfMessage) &&
+                Objects.equals(supplier, that.supplier);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(countryCode, salesCategory, creationDateOfMessage);
+        return Objects.hash(countryCode, salesCategory, creationDateOfMessage, supplier);
     }
 }

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBeanTest.java
@@ -519,7 +519,19 @@ public class SalesRulesServiceBeanTest {
         doReturn(false).when(salesService).isIdNotUnique("referencedID", SalesMessageIdType.SALES_REFERENCED_ID);
 
         assertTrue(service.doesReferencedIdNotExist(fact));
-        verify(salesService).isIdNotUnique("referencedID", SalesMessageIdType.SALES_REFERENCED_ID);
+        verify(salesService, times(2)).isIdNotUnique("referencedID", SalesMessageIdType.SALES_REFERENCED_ID);
+        verifyNoMoreInteractions(salesService);
+    }
+
+    @Test
+    public void doesReferencedIdNotExistWhenItDoesNotExistTheFirstTryButItDoesExistOnTheSecondTry() throws Exception {
+        SalesFLUXResponseDocumentFact fact = new SalesFLUXResponseDocumentFact();
+        fact.setReferencedID(new IdType("referencedID"));
+
+        when(salesService.isIdNotUnique("referencedID", SalesMessageIdType.SALES_REFERENCED_ID)).thenReturn(false, true);
+
+        assertFalse(service.doesReferencedIdNotExist(fact));
+        verify(salesService, times(2)).isIdNotUnique("referencedID", SalesMessageIdType.SALES_REFERENCED_ID);
         verifyNoMoreInteractions(salesService);
     }
 
@@ -534,7 +546,6 @@ public class SalesRulesServiceBeanTest {
         verify(salesService).isIdNotUnique("referencedID", SalesMessageIdType.SALES_REFERENCED_ID);
         verifyNoMoreInteractions(salesService);
     }
-
 
     @Test
     public void doesReferencedIdNotExistWhenFactIsNull() throws Exception {

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/sales/SalesRulesServiceBeanTest.java
@@ -7,8 +7,8 @@ import eu.europa.ec.fisheries.schema.sales.*;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingActivitySummary;
 import eu.europa.ec.fisheries.uvms.activity.model.schemas.FishingTripResponse;
 import eu.europa.ec.fisheries.uvms.rules.service.ActivityService;
-import eu.europa.ec.fisheries.uvms.rules.service.SalesService;
 import eu.europa.ec.fisheries.uvms.rules.service.MDRCacheRuleService;
+import eu.europa.ec.fisheries.uvms.rules.service.SalesService;
 import eu.europa.ec.fisheries.uvms.rules.service.business.fact.CodeType;
 import eu.europa.ec.fisheries.uvms.rules.service.business.fact.*;
 import eu.europa.ec.fisheries.uvms.rules.service.constants.MDRAcronymType;
@@ -227,6 +227,34 @@ public class SalesRulesServiceBeanTest {
 
         //mock
         doReturn(fishingTripResponse1).when(activityService).getFishingTrip(fishingTripID);
+
+        //execute
+        assertTrue(service.isReceptionDate24hAfterLandingDeclaration(salesFLUXSalesReportMessageFact));
+    }
+
+    @Test
+    public void isReceptionDate24hAfterLandingDeclarationWhenNoFishingTripIsFound() throws Exception {
+        //data set
+        String fishingTripID = "MLT-TRP-20160630000001";
+
+        DelimitedPeriodType delimitedPeriodType1 = new DelimitedPeriodType()
+                .withStartDateTime(new DateTimeType().withDateTime(DateTime.now().minusHours(1)));
+        DelimitedPeriodType delimitedPeriodType2 = new DelimitedPeriodType()
+                .withStartDateTime(new DateTimeType().withDateTime(DateTime.now().minusHours(49)));
+        FishingActivityType fishingActivityType1 = new FishingActivityType()
+                .withSpecifiedDelimitedPeriods(Arrays.asList(delimitedPeriodType1, delimitedPeriodType2))
+                .withSpecifiedFishingTrip(new FishingTripType().withIDS(new IDType().withValue(fishingTripID)));
+        FishingActivityType fishingActivityType2 = new FishingActivityType()
+                .withSpecifiedDelimitedPeriods(Arrays.asList(delimitedPeriodType2, delimitedPeriodType1))
+                .withSpecifiedFishingTrip(new FishingTripType().withIDS(new IDType().withValue(fishingTripID)));
+
+        SalesReportType salesReportType = new SalesReportType()
+                .withIncludedSalesDocuments(new SalesDocumentType().withSpecifiedFishingActivities(Arrays.asList(fishingActivityType1, fishingActivityType2)));
+        salesFLUXSalesReportMessageFact.setSalesReports(Arrays.asList(salesReportType));
+        salesFLUXSalesReportMessageFact.setFLUXReportDocument(new FLUXReportDocumentType().withCreationDateTime(new DateTimeType().withDateTime(DateTime.now().plusHours(49))));
+
+        //mock
+        doReturn(Optional.absent()).when(activityService).getFishingTrip(fishingTripID);
 
         //execute
         assertTrue(service.isReceptionDate24hAfterLandingDeclaration(salesFLUXSalesReportMessageFact));


### PR DESCRIPTION
This pull requests includes:

- a new Belgium-specific rule
- a workaound for a race condition. In rare case, a response gets validated before the original report is saved. This causes a rule to fire. The workaround: when this rule fires, it is checked again 5 seconds later to make sure it's justified.