### PR TITLE
[unionvms-4709] fixed displaying movement info on alarms

### DIFF
--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/bean/RulesDomainModelBean.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/bean/RulesDomainModelBean.java
@@ -47,6 +47,7 @@ import javax.ejb.Stateless;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 @Stateless
 public class RulesDomainModelBean implements RulesDomainModel {
@@ -782,10 +783,7 @@ public class RulesDomainModelBean implements RulesDomainModel {
         LOG.info("[INFO] Counting open tickets");
         try {
             List<String> validRuleGuids = rulesDao.getCustomRulesForTicketsByUser(userName);
-            if (!validRuleGuids.isEmpty()) {
-                return rulesDao.getNumberOfOpenTickets(validRuleGuids);
-            }
-            return 0;
+            return rulesDao.getNumberOfOpenTickets(validRuleGuids);
         } catch (DaoException e) {
             LOG.error("[ERROR] Error when counting open tickets {}", e.getMessage());
             throw new RulesModelException(e.getMessage(), e);

--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/constant/UvmsConstants.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/constant/UvmsConstants.java
@@ -18,6 +18,7 @@ public final class UvmsConstants {
     public static final String FIND_ALARM_BY_GUID = "AlarmReport.findByGuid";
     public static final String COUNT_OPEN_ALARMS = "AlarmReport.countOpenAlarms";
     public static final String COUNT_OPEN_TICKETS = "AlarmReport.countOpenTickets";
+    public static final String COUNT_OPEN_TICKETS_NO_RULES = "AlarmReport.countOpenTicketsNoRules";
     public static final String FIND_ALARM_REPORT_BY_ASSET_GUID_AND_RULE_GUID = "AlarmReport.findByAssetGuidRuleGuid";
     public static final String GET_RUNNABLE_CUSTOM_RULES = "CustomRule.getValidCustomRule";
     public static final String LIST_CUSTOM_RULES_BY_USER = "CustomRule.listCustomRules";  // rule engine

--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/dao/bean/RulesDaoBean.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/dao/bean/RulesDaoBean.java
@@ -19,7 +19,6 @@ import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
-import javax.persistence.PersistenceException;
 import javax.persistence.TransactionRequiredException;
 import javax.persistence.TypedQuery;
 import java.util.ArrayList;
@@ -131,10 +130,6 @@ public class RulesDaoBean implements RulesDao {
             TypedQuery<Ticket> query = em.createNamedQuery(UvmsConstants.FIND_TICKETS_BY_MOVEMENTS, Ticket.class);
             query.setParameter("movements", movements);
             return query.getResultList();
-        } catch (NoResultException e) {
-            // TODO: Return empty list???
-            log.error("[ No tickets found for movements ]");
-            throw new NoEntityFoundException("[ No tickets found for movements ]", e);
         } catch (Exception e) {
             log.error("[ERROR] when getting Ticket by movements. {}", e.getMessage());
             throw new DaoException("[ERROR] when getting Ticket by movements. ", e);
@@ -160,8 +155,6 @@ public class RulesDaoBean implements RulesDao {
             TypedQuery<String> query = em.createNamedQuery(UvmsConstants.FIND_CUSTOM_RULE_GUID_FOR_TICKETS, String.class);
             query.setParameter("owner", owner);
             return query.getResultList();
-        } catch (NoResultException e) {
-            return new ArrayList<>();
         } catch (Exception e) {
             log.error("[ERROR] when getting Tickets by userName. {}", e.getMessage());
             throw new DaoException("[ERROR] when getting Tickets by userName. ", e);
@@ -182,8 +175,13 @@ public class RulesDaoBean implements RulesDao {
     @Override
     public long getNumberOfOpenTickets(List<String> validRuleGuids) throws DaoException {
         try {
-            TypedQuery<Long> query = em.createNamedQuery(UvmsConstants.COUNT_OPEN_TICKETS, Long.class);
-            query.setParameter("validRuleGuids", validRuleGuids);
+            TypedQuery<Long> query;
+            if (validRuleGuids.isEmpty()) {
+                query = em.createNamedQuery(UvmsConstants.COUNT_OPEN_TICKETS_NO_RULES, Long.class);
+            } else {
+                query = em.createNamedQuery(UvmsConstants.COUNT_OPEN_TICKETS, Long.class);
+                query.setParameter("validRuleGuids", validRuleGuids);
+            }
             return query.getSingleResult();
         } catch (NoResultException e) {
             return 0;

--- a/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/entity/Ticket.java
+++ b/domain/src/main/java/eu/europa/ec/fisheries/uvms/rules/entity/Ticket.java
@@ -27,7 +27,8 @@ import lombok.Data;
 @NamedQueries({
         @NamedQuery(name = UvmsConstants.FIND_TICKET_BY_GUID, query = "SELECT t FROM Ticket t WHERE t.guid = :guid"),
         @NamedQuery(name = UvmsConstants.FIND_TICKET_BY_ASSET_AND_RULE, query = "SELECT t FROM Ticket t WHERE t.assetGuid = :assetGuid and status <> 'CLOSED' and ruleGuid = :ruleGuid"),
-        @NamedQuery(name = UvmsConstants.COUNT_OPEN_TICKETS, query = "SELECT count(t) FROM Ticket t where t.status = 'OPEN' AND t.ruleGuid IN :validRuleGuids"),
+        @NamedQuery(name = UvmsConstants.COUNT_OPEN_TICKETS, query = "SELECT count(t) FROM Ticket t where t.status = 'OPEN' AND (t.ruleGuid IN :validRuleGuids OR t.ruleGuid IS NULL)"),
+        @NamedQuery(name = UvmsConstants.COUNT_OPEN_TICKETS_NO_RULES, query = "SELECT count(t) FROM Ticket t where t.status = 'OPEN' AND t.ruleGuid IS NULL"),
         @NamedQuery(name = UvmsConstants.FIND_TICKETS_BY_MOVEMENTS, query = "SELECT t FROM Ticket t where t.movementGuid IN :movements"),
         @NamedQuery(name = UvmsConstants.COUNT_TICKETS_BY_MOVEMENTS, query = "SELECT count(t) FROM Ticket t where t.movementGuid IN :movements"),
         @NamedQuery(name = UvmsConstants.COUNT_ASSETS_NOT_SENDING, query = "SELECT count(t) FROM Ticket t where t.ruleGuid = :ruleGuid")

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/consumer/bean/RulesEventMessageConsumerBean.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/consumer/bean/RulesEventMessageConsumerBean.java
@@ -118,6 +118,10 @@ public class RulesEventMessageConsumerBean implements MessageListener {
     private Event<EventMessage> createAlarmReceivedEvent;
 
     @Inject
+    @CreateTicketsReceivedEvent
+    private Event<EventMessage> createTicketsReceivedEvent;
+
+    @Inject
     @ErrorEvent
     private Event<EventMessage> errorEvent;
 
@@ -180,6 +184,9 @@ public class RulesEventMessageConsumerBean implements MessageListener {
                     break;
                 case CREATE_ALARMS_REPORT_REQUEST :
                     createAlarmReceivedEvent.fire(eventMessage);
+                    break;
+                case CREATE_TICKETS_REQUEST:
+                    createTicketsReceivedEvent.fire(eventMessage);
                     break;
                 default:
                     LOG.error("[ Request method '{}' is not implemented ]", method.name());

--- a/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/event/CreateTicketsReceivedEvent.java
+++ b/message/src/main/java/eu/europa/ec/fisheries/uvms/rules/message/event/CreateTicketsReceivedEvent.java
@@ -1,0 +1,25 @@
+/*
+﻿Developed with the contribution of the European Commission - Directorate General for Maritime Affairs and Fisheries
+© European Union, 2015-2016.
+
+This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can
+redistribute it and/or modify it under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or any later version. The IFDM Suite is distributed in
+the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a
+copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.rules.message.event;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE })
+public @interface CreateTicketsReceivedEvent {
+
+}

--- a/model/src/main/resources/contract/Movement.xsd
+++ b/model/src/main/resources/contract/Movement.xsd
@@ -18,6 +18,7 @@
             <xsd:element name="pluginName" type="xsd:string"/>
 
             <xsd:element name="guid" type="xsd:string"/> <!-- unionvms specific -->
+            <xsd:element name="guidGenerated" type="xsd:boolean"/>
             <xsd:element name="connectId" type="xsd:string"/> <!-- unionvms specific -->
             <xsd:element name="assetId" type="asset:AssetId"/>
             <xsd:element name="comChannelType" type="movement:MovementComChannelType"/>

--- a/model/src/main/resources/contract/RulesModuleService.wsdl
+++ b/model/src/main/resources/contract/RulesModuleService.wsdl
@@ -65,6 +65,7 @@
                     <xsd:enumeration value="SEND_SALES_RESPONSE"/>
                     <xsd:enumeration value="GET_VALIDATION_RESULT_BY_RAW_GUID_REQUEST"/>
                     <xsd:enumeration value="CREATE_ALARMS_REPORT_REQUEST"/>
+                    <xsd:enumeration value="CREATE_TICKETS_REQUEST"/>
                 </xsd:restriction>
             </xsd:simpleType>
 
@@ -400,7 +401,7 @@
                     <xsd:complexContent>
                         <xsd:extension base="module:RulesBaseRequest">
                             <xsd:sequence>
-                                <xsd:element name="ticket" type="ticket:TicketType"/>
+                                <xsd:element name="tickets" type="ticket:TicketType" maxOccurs="unbounded"/>
                             </xsd:sequence>
                         </xsd:extension>
                     </xsd:complexContent>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/JmsMovementClient.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/JmsMovementClient.java
@@ -1,0 +1,72 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2020.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.rules.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.module.v1.FindRawMovementsRequest;
+import eu.europa.ec.fisheries.schema.movement.module.v1.FindRawMovementsResponse;
+import eu.europa.ec.fisheries.uvms.commons.message.api.MessageException;
+import eu.europa.ec.fisheries.uvms.movement.model.exception.MovementModelException;
+import eu.europa.ec.fisheries.uvms.movement.model.mapper.JAXBMarshaller;
+import eu.europa.ec.fisheries.uvms.rules.message.consumer.bean.RulesResponseConsumerBean;
+import eu.europa.ec.fisheries.uvms.rules.message.producer.bean.RulesProducerBean;
+import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesServiceTechnicalException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.jms.Queue;
+import javax.jms.TextMessage;
+
+/**
+ * JMS implementation of the {@link MovementClient}.
+ */
+@ApplicationScoped
+public class JmsMovementClient implements MovementClient {
+
+    private RulesProducerBean rulesProducerBean;
+    private RulesResponseConsumerBean rulesResponseConsumerBean;
+    private Queue movementQueue;
+
+    /**
+     * Injection constructor.
+     *
+     * @param rulesProducerBean         The rules module producer bean
+     * @param rulesResponseConsumerBean The rules module consumer bean
+     * @param movementQueue            The movement specific queue created by ManagedObjectsProducer
+     */
+    @Inject
+    public JmsMovementClient(RulesProducerBean rulesProducerBean, RulesResponseConsumerBean rulesResponseConsumerBean, @MovementQueue Queue movementQueue) {
+        this.rulesProducerBean = rulesProducerBean;
+        this.rulesResponseConsumerBean = rulesResponseConsumerBean;
+        this.movementQueue = movementQueue;
+    }
+
+    /**
+     * Constructor for frameworks.
+     */
+    @SuppressWarnings("unused")
+    JmsMovementClient() {
+        // NOOP
+    }
+
+    @Override
+    public FindRawMovementsResponse findRawMovements(FindRawMovementsRequest request) throws MovementModelException {
+        try {
+            String correlationId = rulesProducerBean.sendMessageToSpecificQueue(JAXBMarshaller.marshallJaxBObjectToString(request), movementQueue, rulesResponseConsumerBean.getDestination());
+            FindRawMovementsResponse response = null;
+            if (correlationId != null) {
+                TextMessage textMessage = rulesResponseConsumerBean.getMessage(correlationId, TextMessage.class);
+                response = JAXBMarshaller.unmarshallTextMessage(textMessage, FindRawMovementsResponse.class);
+            }
+            return response;
+        } catch (MessageException e) {
+            throw new RulesServiceTechnicalException("error while calling findRawMovements", e);
+        }
+    }
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/ManagedObjectsProducer.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/ManagedObjectsProducer.java
@@ -1,0 +1,33 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.rules.movement.communication;
+
+import eu.europa.ec.fisheries.uvms.commons.message.api.MessageConstants;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.jms.Queue;
+
+/**
+ * Introduces various Movement-related application server objects into CDI.
+ */
+@Dependent
+class ManagedObjectsProducer {
+
+	@Resource(mappedName = "java:/" + MessageConstants.QUEUE_MODULE_MOVEMENT)
+	private Queue movementQueue;
+
+	@Produces @ApplicationScoped @MovementQueue
+	public Queue getMovementQueue() {
+		return movementQueue;
+	}
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementClient.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementClient.java
@@ -1,0 +1,28 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2020.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.rules.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.module.v1.FindRawMovementsRequest;
+import eu.europa.ec.fisheries.schema.movement.module.v1.FindRawMovementsResponse;
+import eu.europa.ec.fisheries.uvms.movement.model.exception.MovementModelException;
+
+/**
+ * Low-level client to interesting Movement module services.
+ */
+public interface MovementClient {
+
+    /**
+     * Call @{@code FIND_RAW_MOVEMENTS}
+     *
+     * @param request the movement module request
+     * @return The movement module response
+     */
+    FindRawMovementsResponse findRawMovements(FindRawMovementsRequest request) throws MovementModelException;
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementQueue.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementQueue.java
@@ -1,0 +1,25 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.rules.movement.communication;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier for injecting the Movement queue.
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+public @interface MovementQueue {
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementSender.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementSender.java
@@ -1,0 +1,28 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.rules.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.v1.MovementBaseType;
+import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesServiceException;
+
+import java.util.List;
+
+/**
+ * Service for sending messages to Movement.
+ */
+public interface MovementSender {
+
+
+	/**
+	 * @param guildList the guid list used to filter and fetch movements
+	 * @return a list of {@code MovementBaseType}
+	 */
+	List<MovementBaseType> findRawMovements(List<String> guildList) throws RulesServiceException;
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementSenderImpl.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/movement/communication/MovementSenderImpl.java
@@ -1,0 +1,62 @@
+/*
+ Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2016.
+
+ This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.europa.ec.fisheries.uvms.rules.movement.communication;
+
+import eu.europa.ec.fisheries.schema.movement.module.v1.FindRawMovementsRequest;
+import eu.europa.ec.fisheries.schema.movement.module.v1.FindRawMovementsResponse;
+import eu.europa.ec.fisheries.schema.movement.module.v1.MovementModuleMethod;
+import eu.europa.ec.fisheries.schema.movement.v1.MovementBaseType;
+import eu.europa.ec.fisheries.uvms.movement.model.exception.MovementModelException;
+import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesServiceException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+
+/**
+ * Implementation of {@link MovementSender}.
+ */
+@ApplicationScoped
+class MovementSenderImpl implements MovementSender {
+
+    private MovementClient movementClient;
+
+    /**
+     * Injection constructor
+     *
+     * @param movementClient The low-level client to the services of the activity module
+     */
+    @Inject
+    public MovementSenderImpl(MovementClient movementClient) {
+        this.movementClient = movementClient;
+    }
+
+    /**
+     * Constructor for frameworks.
+     */
+    @SuppressWarnings("unused")
+    MovementSenderImpl() {
+        // NOOP
+    }
+
+    @Override
+    public List<MovementBaseType> findRawMovements(List<String> guildList) throws RulesServiceException {
+        try {
+            FindRawMovementsRequest request = new FindRawMovementsRequest();
+            request.setMethod(MovementModuleMethod.FIND_RAW_MOVEMENTS);
+            request.getMovementGuids().addAll(guildList);
+            FindRawMovementsResponse response = null;
+            response = movementClient.findRawMovements(request);
+            return response != null ? response.getResponse() : null;
+        } catch (MovementModelException e) {
+            throw new RulesServiceException("error converting to movement model", e);
+        }
+    }
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/EventService.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/EventService.java
@@ -70,4 +70,6 @@ public interface EventService {
     void sendFluxMovementReportEvent(@Observes @SendFluxMovementReportEvent EventMessage message);
 
     void createAlarmReceivedEvent(@Observes @CreateAlarmReceivedEvent EventMessage message);
+
+    void createTicketsReceivedEvent(@Observes @CreateTicketsReceivedEvent EventMessage message);
 }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/RulesEventServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/RulesEventServiceBean.java
@@ -35,7 +35,7 @@ import eu.europa.ec.fisheries.uvms.rules.service.EventService;
 import eu.europa.ec.fisheries.uvms.rules.service.bean.activity.RulesFAResponseServiceBean;
 import eu.europa.ec.fisheries.uvms.rules.service.bean.activity.RulesFaQueryServiceBean;
 import eu.europa.ec.fisheries.uvms.rules.service.bean.activity.RulesFaReportServiceBean;
-import eu.europa.ec.fisheries.uvms.rules.service.bean.alarms.AlarmReportsServiceBean;
+import eu.europa.ec.fisheries.uvms.rules.service.bean.alarms.AlarmsServiceBean;
 import eu.europa.ec.fisheries.uvms.rules.service.bean.mdr.MdrRulesMessageServiceBean;
 import eu.europa.ec.fisheries.uvms.rules.service.bean.movement.RulesMovementProcessorBean;
 import eu.europa.ec.fisheries.uvms.rules.service.bean.sales.SalesRulesMessageServiceBean;
@@ -88,7 +88,7 @@ public class RulesEventServiceBean implements EventService {
     private SalesRulesMessageServiceBean salesRulesMessageServiceBean;
 
     @EJB
-    private AlarmReportsServiceBean alarmReportsServiceBean;
+    private AlarmsServiceBean alarmsServiceBean;
 
     @Override
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
@@ -333,7 +333,18 @@ public class RulesEventServiceBean implements EventService {
         log.info("Received event to create alarm..");
         try {
             CreateAlarmsReportRequest request = (CreateAlarmsReportRequest) message.getRulesBaseRequest();
-            alarmReportsServiceBean.createAlarmReport(request);
+            alarmsServiceBean.createAlarmReport(request);
+        } catch (RulesServiceException e) {
+            log.error(" Error when creating creating alarm {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void createTicketsReceivedEvent(@Observes @CreateTicketsReceivedEvent EventMessage message) {
+        log.info("Received event to create tickets..");
+        try {
+            CreateTicketRequest request = (CreateTicketRequest) message.getRulesBaseRequest();
+            alarmsServiceBean.createTickets(request);
         } catch (RulesServiceException e) {
             log.error(" Error when creating creating alarm {}", e.getMessage());
         }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/alarms/RawMovementTypeMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/alarms/RawMovementTypeMapper.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2020.
+ *
+ *  This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ *  and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ *  the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package eu.europa.ec.fisheries.uvms.rules.service.bean.alarms;
+
+import eu.europa.ec.fisheries.schema.movement.v1.MovementBaseType;
+import eu.europa.ec.fisheries.schema.rules.movement.v1.RawMovementType;
+
+public class RawMovementTypeMapper {
+    public static void enrichRawMovement(RawMovementType rawMovementType, MovementBaseType movementBaseType) {
+        if(movementBaseType.getActivity() != null){
+            rawMovementType.setActivity(toActivityType(movementBaseType.getActivity()));
+        }
+        rawMovementType.setPosition(toPoint(movementBaseType.getPosition()));
+        rawMovementType.setPositionTime(movementBaseType.getPositionTime());
+        rawMovementType.setReportedCourse(movementBaseType.getReportedCourse());
+        rawMovementType.setReportedSpeed(movementBaseType.getReportedSpeed());
+        if(movementBaseType.getSource() != null){
+            rawMovementType.setSource(eu.europa.ec.fisheries.schema.rules.movement.v1.MovementSourceType.valueOf(movementBaseType.getSource().name()));
+        }
+        if(movementBaseType.getMovementType() != null){
+            rawMovementType.setMovementType(eu.europa.ec.fisheries.schema.rules.movement.v1.MovementTypeType.valueOf(movementBaseType.getMovementType().name()));
+        }
+        rawMovementType.setTripNumber(movementBaseType.getTripNumber());
+        rawMovementType.setStatus(movementBaseType.getStatus());
+    }
+
+    static eu.europa.ec.fisheries.schema.rules.movement.v1.MovementActivityType toActivityType(eu.europa.ec.fisheries.schema.movement.v1.MovementActivityType movementActivityType){
+        eu.europa.ec.fisheries.schema.rules.movement.v1.MovementActivityType activityType = new eu.europa.ec.fisheries.schema.rules.movement.v1.MovementActivityType();
+        activityType.setCallback(movementActivityType.getCallback());
+        activityType.setMessageId(movementActivityType.getMessageId());
+        if(movementActivityType.getMessageType() != null){
+            activityType.setMessageType(eu.europa.ec.fisheries.schema.rules.movement.v1.MovementActivityTypeType.valueOf(movementActivityType.getMessageType().name()));
+        }
+        return activityType;
+    }
+    static eu.europa.ec.fisheries.schema.rules.movement.v1.MovementPoint toPoint(eu.europa.ec.fisheries.schema.movement.v1.MovementPoint movementPoint){
+        eu.europa.ec.fisheries.schema.rules.movement.v1.MovementPoint point = new eu.europa.ec.fisheries.schema.rules.movement.v1.MovementPoint();
+        point.setAltitude(movementPoint.getAltitude());
+        point.setLatitude(movementPoint.getLatitude());
+        point.setLongitude(movementPoint.getLongitude());
+        return point;
+    }
+
+}

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/movement/MovementValidationServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/rules/service/bean/movement/MovementValidationServiceBean.java
@@ -574,11 +574,10 @@ public class MovementValidationServiceBean implements ValidationService {
     @Override
     public long getNumberOfOpenTickets(String userName) throws RulesServiceException, RulesFaultException {
         try {
-            long numberOfOpenTickets = rulesDomainModel.getNumberOfOpenTickets(userName);
-            return numberOfOpenTickets;
+            return rulesDomainModel.getNumberOfOpenTickets(userName);
         } catch (RulesModelException e) {
             LOG.error("[ Error when getting number of open tickets ] {}", e.getMessage());
-            throw new RulesServiceException("[ Error when getting number of open alarms. ]");
+            throw new RulesServiceException("[ Error when getting number of open alarms. ]",e);
         }
     }
 

--- a/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/alarms/AlarmsServiceBeanTest.java
+++ b/service/src/test/java/eu/europa/ec/fisheries/uvms/rules/service/bean/alarms/AlarmsServiceBeanTest.java
@@ -1,0 +1,196 @@
+/*
+ *
+ *  Developed by the European Commission - Directorate General for Maritime Affairs and Fisheries @ European Union, 2015-2020.
+ *
+ *  This file is part of the Integrated Fisheries Data Management (IFDM) Suite. The IFDM Suite is free software: you can redistribute it
+ *  and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ *  the License, or any later version. The IFDM Suite is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  details. You should have received a copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package eu.europa.ec.fisheries.uvms.rules.service.bean.alarms;
+
+import eu.europa.ec.fisheries.remote.RulesDomainModel;
+import eu.europa.ec.fisheries.schema.movement.v1.MovementBaseType;
+import eu.europa.ec.fisheries.schema.movement.v1.MovementPoint;
+import eu.europa.ec.fisheries.schema.movement.v1.MovementTypeType;
+import eu.europa.ec.fisheries.schema.rules.alarm.v1.AlarmItemType;
+import eu.europa.ec.fisheries.schema.rules.alarm.v1.AlarmReportType;
+import eu.europa.ec.fisheries.schema.rules.alarm.v1.AlarmStatusType;
+import eu.europa.ec.fisheries.schema.rules.asset.v1.AssetId;
+import eu.europa.ec.fisheries.schema.rules.asset.v1.AssetIdList;
+import eu.europa.ec.fisheries.schema.rules.asset.v1.AssetIdType;
+import eu.europa.ec.fisheries.schema.rules.asset.v1.AssetType;
+import eu.europa.ec.fisheries.schema.rules.module.v1.CreateAlarmsReportRequest;
+import eu.europa.ec.fisheries.schema.rules.movement.v1.RawMovementType;
+import eu.europa.ec.fisheries.uvms.commons.notifications.NotificationMessage;
+import eu.europa.ec.fisheries.uvms.rules.message.consumer.RulesResponseConsumer;
+import eu.europa.ec.fisheries.uvms.rules.message.producer.bean.RulesAuditProducerBean;
+import eu.europa.ec.fisheries.uvms.rules.movement.communication.MovementSender;
+import eu.europa.ec.fisheries.uvms.rules.service.exception.RulesServiceException;
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.enterprise.event.Event;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the {@link AlarmsServiceBeanTest}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AlarmsServiceBeanTest {
+
+    private static final String DELTA_GUID = "97a40d34-45ea-11e7-bec7-4c32759615eb";
+    @Mock
+    private RulesDomainModel rulesDomainModel;
+    @Mock
+    private Event<NotificationMessage> alarmReportEvent;
+    @Mock
+    private Event<NotificationMessage> alarmReportCountEvent;
+    @Mock
+    private RulesAuditProducerBean auditProducer;
+    @Mock
+    private RulesResponseConsumer consumer;
+    @Mock
+    private MovementSender movementSender;
+
+    @InjectMocks
+    private AlarmsServiceBean sut;
+
+    @Test(expected = RulesServiceException.class)
+    public void testCreateAlarmReportWithoutAlarmItemAndExpectServiceException(){
+        CreateAlarmsReportRequest request = request(
+                                                report( DELTA_GUID ,false));
+        sut.createAlarmReport(request);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testCreateAlarmReportWithEnrichedDataOfMovementModule(){
+        CreateAlarmsReportRequest request = request(
+                report( DELTA_GUID,false ,item("test")));
+        List<MovementBaseType> movementBaseTypes = new ArrayList<>();
+        MovementBaseType responseItem = responseItem(DELTA_GUID);
+        movementBaseTypes.add(responseItem);
+
+        when(movementSender.findRawMovements(any())).thenReturn(movementBaseTypes);
+        when(rulesDomainModel.createAlarmReport(any(AlarmReportType.class))).thenAnswer(returnsFirstArg());
+        AlarmReportType createdReport = sut.createAlarmReport(request).get(0);
+        assertNotNull(createdReport.getRawMovement().getPosition());
+        assertEquals(createdReport.getRawMovement().getMovementType().name(),responseItem.getMovementType().name());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testCreateAlarmReportWithoutEnrichedDataOfMovementModule(){
+        CreateAlarmsReportRequest request = request(
+                report( UUID.randomUUID().toString(),true ,item("test")));
+        List<MovementBaseType> movementBaseTypes = new ArrayList<>();
+        MovementBaseType responseItem = responseItem(DELTA_GUID);
+        movementBaseTypes.add(responseItem);
+
+        when(movementSender.findRawMovements(any())).thenReturn(movementBaseTypes);
+        when(rulesDomainModel.createAlarmReport(any(AlarmReportType.class))).thenAnswer(returnsFirstArg());
+        AlarmReportType createdReport = sut.createAlarmReport(request).get(0);
+        assertNull(createdReport.getRawMovement().getPosition());
+    }
+
+    private static CreateAlarmsReportRequest request(AlarmReportType... reports){
+        CreateAlarmsReportRequest request = new CreateAlarmsReportRequest();
+        for(AlarmReportType report : reports)
+            request.getAlarm().add(report);
+        return request;
+    }
+
+    private MovementBaseType responseItem(String guid){
+        MovementBaseType movementBaseType = new MovementBaseType();
+        movementBaseType.setGuid(guid);
+        movementBaseType.setDuplicate(false);
+        movementBaseType.setReportedCourse(180.0);
+        movementBaseType.setReportedSpeed(14.0);
+        MovementPoint movementPoint = new MovementPoint();
+        movementPoint.setLongitude(41.17);
+        movementPoint.setLatitude(18.10);
+        movementBaseType.setPosition(movementPoint);
+        movementBaseType.setMovementType(MovementTypeType.POS);
+        movementBaseType.setPositionTime(new Date());
+        return movementBaseType;
+    }
+
+    private static AlarmReportType report(String assetGuid,boolean guidGenerated,AlarmItemType... items){
+        AlarmReportType alarmReportType = new AlarmReportType();
+        for(AlarmItemType item : items)
+            alarmReportType.getAlarmItem().add(item);
+        alarmReportType.setAssetGuid(assetGuid);
+        alarmReportType.setRawMovement(raw( rowData(assetGuid,guidGenerated,null,"XR003","SVK","SVK123456789","IRCS3")));
+        alarmReportType.setStatus(AlarmStatusType.OPEN);
+        alarmReportType.setGuid(UUID.randomUUID().toString());
+        return alarmReportType;
+    }
+
+    private static RawMovementType raw(SubscriptionRowData rowData){
+        RawMovementType raw = new RawMovementType();
+        raw.setFlagState(rowData.flagState);
+        raw.setGuid(rowData.guid);
+        raw.setGuidGenerated(rowData.guidGenerated);
+        raw.setConnectId(rowData.connectId);
+        raw.setExternalMarking(rowData.extMark);
+        raw.setFlagState(rowData.extMark);
+        return raw;
+    }
+
+    private static AlarmItemType item(String ruleName){
+        AlarmItemType item = new AlarmItemType();
+        item.setRuleName(ruleName);
+        item.setGuid(UUID.randomUUID().toString());
+        return item;
+    }
+
+    private static SubscriptionRowData rowData(String guid,boolean guidGenerated,String connectId,String extMark,String flagState,String cfr,String ircs){
+        SubscriptionRowData rawData = new SubscriptionRowData();
+        AssetId assetId = new AssetId();
+        assetId.setAssetType(AssetType.VESSEL);
+        addVesselIdIfNotNull(assetId, AssetIdType.CFR, cfr);
+        addVesselIdIfNotNull(assetId, AssetIdType.IRCS, ircs);
+        rawData.assetId = assetId;
+        rawData.guid = guid;
+        rawData.guidGenerated = guidGenerated;
+        rawData.connectId = connectId;
+        rawData.extMark = extMark;
+        rawData.flagState = flagState;
+        return rawData;
+    }
+
+    private static void addVesselIdIfNotNull(AssetId assetId, AssetIdType assetIdType, String value) {
+        if (value != null) {
+            AssetIdList assetIdList = new AssetIdList();
+            assetIdList.setIdType(assetIdType);
+            assetIdList.setValue(value);
+            assetId.getAssetIdList().add(assetIdList);
+        }
+    }
+
+    private static class SubscriptionRowData{
+        AssetId assetId;
+        String guid;
+        boolean guidGenerated;
+        String connectId;
+        String extMark;
+        String flagState;
+    }
+}


### PR DESCRIPTION
In order to enrich rawmovement with detail information for a movement, when alarm triggered through subscription, asking movement module.
Added jms client and the enriching with details.
Added AlarmReportsServiceBeanTest and moved RawMovementType mapping from MovementBaseTypeMapper to RawMovementTypeMapper